### PR TITLE
fix: correct scores CLI commands in reference

### DIFF
--- a/skills/langfuse/references/cli.md
+++ b/skills/langfuse/references/cli.md
@@ -71,8 +71,9 @@ langfuse api dataset-items list --dataset-name my-dataset
 ### Scores
 
 ```bash
-langfuse api scores list --limit 20
-langfuse api score-configs list
+langfuse api score-v2s get-scores --limit 20
+langfuse api score-v2s get-get-by-id <score-id>
+langfuse api score-configs get-public
 ```
 
 ### Sessions
@@ -90,3 +91,4 @@ langfuse api sessions get <session-id>
 - All list commands support filtering — check `<resource> <action> --help` for available options
 - Prefer `observations-v2s` over `observations` — the v2 endpoint returns richer data
 - Prefer `metrics-v2s` over `metrics` — the v2 endpoint returns richer data
+- Prefer `score-v2s` over `scores` — the v1 `scores` resource only supports create/delete; use `score-v2s` for list and get operations


### PR DESCRIPTION
## Title

fix: correct scores CLI commands in reference

## Body

### Summary

The Scores section in `skills/langfuse/references/cli.md` listed commands that don't exist in the actual CLI (`langfuse-cli`). Updated to match the real CLI behavior, verified by running each command.

### Changes

| Before (incorrect) | After (verified) |
|---|---|
| `langfuse api scores list --limit 20` | `langfuse api score-v2s get-scores --limit 20` |
| (missing) | `langfuse api score-v2s get-get-by-id <score-id>` |
| `langfuse api score-configs list` | `langfuse api score-configs get-public` |

Also added `score-v2s` to the "prefer v2" tips in the Tips section, consistent with existing entries for `observations-v2s` and `metrics-v2s`.

### Why this matters

Agents using this skill reference attempt `api scores list`, which doesn't exist (the `scores` resource only has `create`/`delete`). This causes agents to waste multiple tool calls trying to find how to retrieve scores, when the correct command is `api score-v2s get-scores`.

### Verification

All commands verified against `langfuse-cli` (via `npx langfuse-cli`):

```
$ langfuse api scores --help
→ Commands: create, delete (no list/get)

$ langfuse api score-v2s --help
→ Commands: get-scores, get-get-by-id

$ langfuse api score-v2s get-scores --limit 3 --json
→ Successfully returns score data (value, comment, traceId, etc.)

$ langfuse api score-configs --help
→ Commands: create, get-get-by-id, get-public, update (no "list")
```

### Note

The `langfuse-cli` README ([langfuse/langfuse-cli](https://github.com/langfuse/langfuse-cli)) also contains `langfuse api scores list --limit 20` in its usage examples — the same issue exists there.