### PR TITLE
adding specific use cases to main skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 
 | Skill                                                           | Description                                                                                        |
 | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| [langfuse](./skills/langfuse)                                   | Query and manage traces, prompts, datasets, and scores via the Langfuse API; look up documentation |
-| [langfuse-observability](./skills/langfuse-observability)       | Add Langfuse tracing to LLM applications with framework-specific best practices                    |
-| [langfuse-prompt-migration](./skills/langfuse-prompt-migration) | Migrate hardcoded prompts to Langfuse for version control and deployment-free iteration            |
+| [langfuse](./skills/langfuse)                                   | Main skill to work with Langfuse. Query and manage traces, prompts, datasets, and scores via the Langfuse API; look up documentation; do things with best practices in mind. |
 
 ## Installation
 
@@ -16,8 +14,6 @@ Install via the [skills CLI](https://github.com/anthropics/skills):
 
 ```bash
 npx skills add langfuse/skills --skill "langfuse"
-npx skills add langfuse/skills --skill "langfuse-observability"
-npx skills add langfuse/skills --skill "langfuse-prompt-migration"
 ```
 
 ## Prerequisites

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -5,7 +5,23 @@ description: Interact with Langfuse and access its documentation. Use when needi
 
 # Langfuse
 
-Two core capabilities: **programmatic API access** via the Langfuse CLI, and **documentation retrieval** via llms.txt, page fetching, and search. Don't rely on your existing knowledge about langfuse. It might be outdated. Always fetch the latest documentation.
+This skill helps you use Langfuse effectively across all common workflows: instrumenting applications, migrating prompts, debugging traces, and accessing data programmatically.
+
+## Core Principles
+
+Follow these principles for ALL Langfuse work:
+
+1. **Documentation First**: NEVER implement based on memory. Always fetch current docs before writing code (Langfuse updates frequently) See the section below on how to access documentation.
+2. **CLI for Data Access**: Use `langfuse-cli` when querying/modifying Langfuse data. See the section below on how to use the CLI. 
+3. **Best Practices by Use Case**: Check the relevant reference file below for use-case-specific guidelines before implementing
+4. **Use latest Langfuse versions**: Unless the user specified otherwise or there's a good reason, always use the latest version of Langfuse SDKs/APIs.
+
+
+## Use case specific references
+
+- instrumenting an existing function/application: references/instrumentation.md
+- migrating prompts from a codebase into Langfuse: references/prompt-migration.md
+- further tips on using the Langfuse CLI: references/cli.md
 
 ## 1. Langfuse API via CLI
 

--- a/skills/langfuse/references/instrumentation.md
+++ b/skills/langfuse/references/instrumentation.md
@@ -1,0 +1,139 @@
+---
+name: langfuse-observability
+description: Instrument LLM applications with Langfuse tracing. Use when setting up Langfuse, adding observability to LLM calls, or auditing existing instrumentation.
+---
+
+# Langfuse Observability
+
+Instrument LLM applications with Langfuse tracing, following best practices and tailored to your use case.
+
+## When to Use
+
+- Setting up Langfuse in a new project
+- Auditing existing Langfuse instrumentation
+- Adding observability to LLM calls
+
+## Workflow
+
+### 1. Assess Current State
+
+Check the project:
+
+- Is Langfuse SDK installed?
+- What LLM frameworks are used? (OpenAI SDK, LangChain, LlamaIndex, Vercel AI SDK, etc.)
+- Is there existing instrumentation?
+
+**No integration yet:** Set up Langfuse using a framework integration if available. Integrations capture more context automatically and require less code than manual instrumentation.
+
+**Integration exists:** Audit against baseline requirements below.
+
+### 2. Verify Baseline Requirements
+
+Every trace should have these fundamentals:
+
+| Requirement               | Check                                                                                    | Why                                                    |
+| ------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Model name                | Is the LLM model captured?                                                               | Enables model comparison and filtering                 |
+| Token usage               | Are input/output tokens tracked?                                                         | Enables automatic cost calculation                     |
+| Good trace names          | Are names descriptive? (`chat-response`, not `trace-1`)                                  | Makes traces findable and filterable                   |
+| Span hierarchy            | Are multi-step operations nested properly?                                               | Shows which step is slow or failing                    |
+| Correct observation types | Are generations marked as generations?                                                   | Enables model-specific analytics                       |
+| Sensitive data masked     | Is PII/confidential data excluded or masked?                                             | Prevents data leakage                                  |
+| Trace input/output        | Does the trace capture the full data being processed as input, and the result as output? | Enables debugging and understanding what was processed |
+
+Framework integrations (OpenAI, LangChain, etc.) handle model name, tokens, and observation types automatically. Prefer integrations over manual instrumentation.
+
+Docs: https://langfuse.com/docs/tracing
+
+### 3. Explore Traces First
+
+Once baseline instrumentation is working, encourage the user to explore their traces in the Langfuse UI before adding more context:
+
+"Your traces are now appearing in Langfuse. Take a look at a few of them—see what data is being captured, what's useful, and what's missing. This will help us decide what additional context to add."
+
+This helps the user:
+
+- Understand what they're already getting
+- Form opinions about what's missing
+- Ask better questions about what they need
+
+### 4. Discover Additional Context Needs
+
+Determine what additional instrumentation would be valuable. **Infer from code when possible, only ask when unclear.**
+
+**Infer from code:**
+
+| If you see in code...                                | Infer             | Suggest                   |
+| ---------------------------------------------------- | ----------------- | ------------------------- |
+| Conversation history, chat endpoints, message arrays | Multi-turn app    | `session_id`              |
+| User authentication, `user_id` variables             | User-aware app    | `user_id` on traces       |
+| Multiple distinct endpoints/features                 | Multi-feature app | `feature` tag             |
+| Customer/tenant identifiers                          | Multi-tenant app  | `customer_id` or tier tag |
+| Feedback collection, ratings                         | Has user feedback | Capture as scores         |
+
+**Only ask when not obvious from code:**
+
+- "How do you know when a response is good vs bad?" → Determines scoring approach
+- "What would you want to filter by in a dashboard?" → Surfaces non-obvious tags
+- "Are there different user segments you'd want to compare?" → Customer tiers, plans, etc.
+
+**Additions and their value:**
+
+| Addition            | Why                                         | Docs                                                |
+| ------------------- | ------------------------------------------- | --------------------------------------------------- |
+| `session_id`        | Groups conversations together               | https://langfuse.com/docs/tracing-features/sessions |
+| `user_id`           | Enables user filtering and cost attribution | https://langfuse.com/docs/tracing-features/users    |
+| User feedback score | Enables quality filtering and trends        | https://langfuse.com/docs/scores/overview           |
+| `feature` tag       | Per-feature analytics                       | https://langfuse.com/docs/tracing-features/tags     |
+| `customer_tier` tag | Cost/quality breakdown by segment           | https://langfuse.com/docs/tracing-features/tags     |
+
+These are NOT baseline requirements—only add what's relevant based on inference or user input.
+
+### 5. Guide to UI
+
+After adding context, point users to relevant UI features:
+
+- Traces view: See individual requests
+- Sessions view: See grouped conversations (if session_id added)
+- Dashboard: Build filtered views using tags
+- Scores: Filter by quality metrics
+
+## Framework Integrations
+
+Prefer these over manual instrumentation:
+
+| Framework     | Integration            | Docs                                                 |
+| ------------- | ---------------------- | ---------------------------------------------------- |
+| OpenAI SDK    | Drop-in replacement    | https://langfuse.com/docs/integrations/openai        |
+| LangChain     | Callback handler       | https://langfuse.com/docs/integrations/langchain     |
+| LlamaIndex    | Callback handler       | https://langfuse.com/docs/integrations/llama-index   |
+| Vercel AI SDK | OpenTelemetry exporter | https://langfuse.com/docs/integrations/vercel-ai-sdk |
+| LiteLLM       | Callback or proxy      | https://langfuse.com/docs/integrations/litellm       |
+
+Full list: https://langfuse.com/docs/integrations
+
+## Always Explain Why
+
+When suggesting additions, explain the user benefit:
+
+```
+"I recommend adding session_id to your traces.
+
+Why: This groups messages from the same conversation together.
+You'll be able to see full conversation flows in the Sessions view,
+making it much easier to debug multi-turn interactions.
+
+Learn more: https://langfuse.com/docs/tracing-features/sessions"
+```
+
+## Common Mistakes
+
+| Mistake                                        | Problem                                             | Fix                                                                               |
+| ---------------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------- |
+| No `flush()` in scripts                        | Traces never sent                                   | Call `langfuse.flush()` before exit                                               |
+| Flat traces                                    | Can't see which step failed                         | Use nested spans for distinct steps                                               |
+| Generic trace names                            | Hard to filter                                      | Use descriptive names: `chat-response`, `doc-summary`                             |
+| Logging sensitive data                         | Data leakage risk                                   | Mask PII before tracing                                                           |
+| Manual instrumentation when integration exists | More code, less context                             | Use framework integration                                                         |
+| Langfuse import before env vars loaded         | Langfuse initializes with missing/wrong credentials | Import Langfuse AFTER loading environment variables (e.g., after `load_dotenv()`) |
+| Wrong import order with OpenAI                 | Langfuse can't patch the OpenAI client              | Import Langfuse and call its setup BEFORE importing OpenAI client                 |

--- a/skills/langfuse/references/prompt-migration.md
+++ b/skills/langfuse/references/prompt-migration.md
@@ -1,0 +1,218 @@
+---
+name: langfuse-prompt-migration
+description: Migrate hardcoded prompts to Langfuse for version control and deployment-free iteration. Use when user wants to externalize prompts, move prompts to Langfuse, or set up prompt management.
+---
+
+# Langfuse Prompt Migration
+
+Migrate hardcoded prompts to Langfuse for version control, A/B testing, and deployment-free iteration.
+
+## Prerequisites
+
+Verify credentials before starting:
+
+```bash
+echo $LANGFUSE_PUBLIC_KEY   # pk-...
+echo $LANGFUSE_SECRET_KEY   # sk-...
+echo $LANGFUSE_HOST         # https://cloud.langfuse.com or self-hosted
+```
+
+If not set, ask user to configure them first.
+
+## Migration Flow
+
+```
+1. Scan codebase for prompts
+2. Analyze templating compatibility
+3. Propose structure (names, subprompts, variables)
+4. User approves
+5. Create prompts in Langfuse
+6. Refactor code to use get_prompt()
+7. Link prompts to traces (if tracing enabled)
+8. Verify application works
+```
+
+## Step 1: Find Prompts
+
+Search for these patterns:
+
+| Framework | Look for |
+|-----------|----------|
+| OpenAI | `messages=[{"role": "system", "content": "..."}]` |
+| Anthropic | `system="..."` |
+| LangChain | `ChatPromptTemplate`, `SystemMessage` |
+| Vercel AI | `system: "..."`, `prompt: "..."` |
+| Raw | Multi-line strings near LLM calls |
+
+## Step 2: Check Templating Compatibility
+
+**CRITICAL:** Langfuse only supports simple `{{variable}}` substitution. No conditionals, loops, or filters.
+
+| Template Feature | Langfuse Native | Action |
+|------------------|-----------------|--------|
+| `{{variable}}` | ✅ | Direct migration |
+| `{var}` / `${var}` | ⚠️ | Convert to `{{var}}` |
+| `{% if %}` / `{% for %}` | ❌ | Move logic to code |
+| `{{ var \| filter }}` | ❌ | Apply filter in code |
+
+### Decision Tree
+
+```
+Contains {% if %}, {% for %}, or filters?
+├─ No → Direct migration
+└─ Yes → Choose:
+    ├─ Option A (RECOMMENDED): Move logic to code, pass pre-computed values
+    └─ Option B: Store raw template, compile client-side with Jinja2
+        └─ ⚠️ Loses: Playground preview, UI experiments
+```
+
+### Simplifying Complex Templates
+
+**Conditionals** → Pre-compute in code:
+```python
+# Instead of {% if user.is_premium %}...{% endif %} in prompt
+# Use {{tier_message}} and compute value in code before compile()
+```
+
+**Loops** → Pre-format in code:
+```python
+# Instead of {% for tool in tools %}...{% endfor %} in prompt
+# Use {{tools_list}} and format the list in code before compile()
+```
+
+For external templating details, fetch: https://langfuse.com/faq/all/using-external-templating-libraries
+
+## Step 3: Propose Structure
+
+### Naming Conventions
+
+| Rule | Example | Bad |
+|------|---------|-----|
+| Lowercase, hyphenated | `chat-assistant` | `ChatAssistant_v2` |
+| Feature-based | `document-summarizer` | `prompt1` |
+| Hierarchical for related | `support/triage` | `supportTriage` |
+| Prefix subprompts with `_` | `_base-personality` | `shared-personality` |
+
+### Identify Subprompts
+
+Extract when:
+- Same text in 2+ prompts
+- Represents distinct component (personality, safety rules, format)
+- Would need to change together
+
+### Variable Extraction
+
+| Make Variable | Keep Hardcoded |
+|---------------|----------------|
+| User-specific (`{{user_name}}`) | Output format instructions |
+| Dynamic content (`{{context}}`) | Safety guardrails |
+| Per-request (`{{query}}`) | Persona/personality |
+| Environment-specific (`{{company_name}}`) | Static examples |
+
+## Step 4: Present Plan to User
+
+Format:
+```
+Found N prompts across M files:
+
+src/chat.py:
+  - System prompt (47 lines) → 'chat-assistant'
+
+src/support/triage.py:
+  - Triage prompt (34 lines) → 'support/triage'
+    ⚠️ Contains {% if %} - will simplify
+
+Subprompts to extract:
+  - '_base-personality' - used by: chat-assistant, support/triage
+
+Variables to add:
+  - {{user_name}} - hardcoded in 2 prompts
+
+Proceed?
+```
+
+## Step 5: Create Prompts in Langfuse
+
+Use `langfuse.create_prompt()` with:
+- `name`: Your chosen name
+- `prompt`: Template text (or message array for chat type)
+- `type`: `"text"` or `"chat"`
+- `labels`: `["production"]` (they're already live)
+- `config`: Optional model settings
+
+**Labeling strategy:**
+- `production` → All migrated prompts
+- `staging` → Add later for testing
+- `latest` → Auto-applied by Langfuse
+
+For full API: fetch https://langfuse.com/docs/prompts/get-started
+
+## Step 6: Refactor Code
+
+Replace hardcoded prompts with:
+
+```python
+prompt = langfuse.get_prompt("name", label="production")
+messages = prompt.compile(var1=value1, var2=value2)
+```
+
+**Key points:**
+- Always use `label="production"` (not `latest`) for stability
+- Call `.compile()` to substitute variables
+- For chat prompts, result is message array ready for API
+
+For SDK examples (Python/JS/TS): fetch https://langfuse.com/docs/prompts/get-started
+
+## Step 7: Link Prompts to Traces
+
+If codebase uses Langfuse tracing, link prompts so you can see which version produced each response.
+
+### Detect Existing Tracing
+
+Look for:
+- `@observe()` decorators
+- `langfuse.trace()` calls
+- `from langfuse.openai import openai` (instrumented client)
+
+### Link Methods
+
+| Setup | How to Link |
+|-------|-------------|
+| `@observe()` decorator | `langfuse_context.update_current_observation(prompt=prompt)` |
+| Manual tracing | `trace.generation(prompt=prompt, ...)` |
+| OpenAI integration | `openai.chat.completions.create(..., langfuse_prompt=prompt)` |
+
+### Verify in UI
+
+1. Go to **Traces** → select a trace
+2. Click on **Generation**
+3. Check **Prompt** field shows name and version
+
+For tracing details: fetch https://langfuse.com/docs/prompts/get-started#link-with-langfuse-tracing
+
+## Step 8: Verify Migration
+
+### Checklist
+
+- [ ] All prompts created with `production` label
+- [ ] Code fetches with `label="production"`
+- [ ] Variables compile without errors
+- [ ] Subprompts resolve correctly
+- [ ] Application behavior unchanged
+- [ ] Generations show linked prompt in UI (if tracing)
+
+### Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| `PromptNotFoundError` | Check name spelling |
+| Variables not replaced | Use `{{var}}` not `{var}`, call `.compile()` |
+| Subprompt not resolved | Must exist with same label |
+| Old prompt cached | Restart app |
+
+## Out of Scope
+
+- Prompt engineering (writing better prompts)
+- Evaluation setup
+- A/B testing workflow
+- Non-LLM string templates


### PR DESCRIPTION
- added prompt migration and langfuse observability skill to main langfuse skill under references
- README is updated to only reference main Langfuse skill, but for now still keeping old specific skills too to avoid breaking anything for existing installations