### PR TITLE
Add feedback & skill request section

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas-improvements.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas-improvements.yml
@@ -1,0 +1,13 @@
+title: ""
+labels: []
+body:
+  - type: textarea
+    attributes:
+      label: Describe your idea or feedback
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What would the ideal outcome look like?
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ Once installed, the agent will automatically use these skills when relevant — 
 - Migrating prompts to Langfuse prompt management
 - Querying traces, prompts, or datasets via the API
 - Looking up Langfuse docs, SDK usage, or integration guides
+
+## Feedback & Requests
+
+Something not working as expected, or want a new skill? [Start a discussion](https://github.com/langfuse/skills/discussions/new?category=ideas-improvements).


### PR DESCRIPTION
## Summary
- Adds a "Feedback & Requests" section to the README linking to GitHub Discussions
- Adds a discussion template for the "Ideas & Improvements" category with two fields: "Describe your idea or feedback" and "What would the ideal outcome look like?"
- GitHub Discussions was enabled on the repo with only "Ideas & Improvements" and "Show and tell" categories