### PR TITLE
Add automatic skill feedback submission flow

### DIFF
--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -23,6 +23,7 @@ Follow these principles for ALL Langfuse work:
 - migrating prompts from a codebase into Langfuse: references/prompt-migration.md
 - capturing user feedback (thumbs, ratings, implicit signals) as scores on traces: references/user-feedback.md
 - further tips on using the Langfuse CLI: references/cli.md
+- submitting feedback about this skill: references/skill-feedback.md
 
 ## 1. Langfuse API via CLI
 
@@ -111,3 +112,16 @@ Search is a great fallback if you cannot find the relevant pages or need more co
 1. Start with **llms.txt** to orient — scan for relevant page titles
 2. **Fetch specific pages** when you identify the right one
 3. Fall back to **search** when the topic is unclear and you want more context
+
+## Skill Feedback
+
+When the user expresses that something about this skill is not working as expected, gives incorrect guidance, is missing information, or could be improved — offer to submit feedback to the Langfuse skill maintainers. This includes when:
+
+- The skill gave wrong or outdated instructions
+- A workflow didn't produce the expected result
+- The user wishes the skill covered something it doesn't
+- The user explicitly says something like "this should work differently" or "this is wrong"
+
+**Do NOT trigger this** for issues with Langfuse itself (the product) — only for issues with this skill's instructions and behavior.
+
+When triggered, follow the process in [references/skill-feedback.md](references/skill-feedback.md).

--- a/skills/langfuse/references/skill-feedback.md
+++ b/skills/langfuse/references/skill-feedback.md
@@ -1,0 +1,52 @@
+---
+name: langfuse-skill-feedback
+description: Submit feedback about the Langfuse skill to its maintainers via GitHub Discussions. Use when the user indicates the skill gave incorrect guidance, is missing information, or could be improved.
+---
+
+# Skill Feedback
+
+Follow these steps exactly:
+
+1. **Ask permission**: Ask the user if they'd like you to submit feedback to the skill maintainers. Make it clear this is about the skill (the agent instructions), not about Langfuse the product. If they decline, move on.
+2. **Draft feedback**: Write the feedback using the form structure below. Present the draft to the user and ask if they'd like to change anything before submitting.
+3. **Submit**: Once approved, submit via `gh` CLI as described below. Share the resulting discussion URL with the user.
+
+## Feedback Form Structure
+
+Draft the feedback using these two fields:
+
+**Describe your idea or feedback** (required)
+A clear description of what went wrong or what could be improved. Include:
+- What the user was trying to do
+- What the skill did vs what was expected
+- Any specific instructions that were incorrect or missing
+
+**What would the ideal outcome look like?** (optional)
+What the correct behavior or guidance should be.
+
+Format the body as markdown with the two field labels as headings.
+
+## Submitting
+
+Create a GitHub Discussion on the `langfuse/skills` repository using the GraphQL API:
+
+```bash
+gh api graphql -f query='
+mutation($repoId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+  createDiscussion(input: {repositoryId: $repoId, categoryId: $categoryId, title: $title, body: $body}) {
+    discussion { url }
+  }
+}' \
+  -f repoId="$(gh api graphql -f query='{ repository(owner: "langfuse", name: "skills") { id } }' --jq '.data.repository.id')" \
+  -f categoryId="$(gh api graphql -f query='{ repository(owner: "langfuse", name: "skills") { discussionCategories(first: 10) { nodes { id name } } } }' --jq '.data.repository.discussionCategories.nodes[] | select(.name == "Ideas & Improvements") | .id')" \
+  -f title="<concise title>" \
+  -f body="<formatted feedback>"
+```
+
+If the `gh` CLI is not authenticated or the request fails, give the user this link to create the discussion manually:
+
+```
+https://github.com/langfuse/skills/discussions/new?category=ideas-improvements
+```
+
+After submission, share the discussion URL with the user.


### PR DESCRIPTION
## Summary

- When the user tells the agent something about the skill isn't working as expected, the agent now offers to submit feedback to the skill maintainers via GitHub Discussions
- Adds a "Skill Feedback" section to `SKILL.md` with clear trigger conditions (wrong instructions, unexpected results, missing coverage)
- Adds `references/skill-feedback.md` with the 3-step process: ask permission, draft feedback using the discussion form structure, submit via `gh` CLI (with manual fallback link)
- Only triggers for skill issues, not Langfuse product issues