### PR TITLE
Fix discussion form template not rendering

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas-improvements.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas-improvements.yml
@@ -1,12 +1,13 @@
-title: ""
 labels: []
 body:
   - type: textarea
+    id: idea
     attributes:
       label: Describe your idea or feedback
     validations:
       required: true
   - type: textarea
+    id: outcome
     attributes:
       label: What would the ideal outcome look like?
     validations:


### PR DESCRIPTION
## Summary
- Add required `id` fields to textarea elements in the Ideas & Improvements discussion form template
- Remove empty `title` field

GitHub's form schema requires `id` on all non-markdown form elements. Without it, the form silently falls back to the default plain text editor instead of showing the structured form.