### PR TITLE
feat: improve langfuse skill guidance for trace input, docs access, and feedback UX

### DIFF
--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -61,7 +61,7 @@ For common workflows, tips, and full usage patterns, see [references/cli.md](ref
 
 ## 2. Langfuse Documentation
 
-Three methods to access Langfuse docs, in order of preference:
+Three methods to access Langfuse docs, in order of preference. **Always prefer your application's native web fetch and search tools** (e.g., `WebFetch`, `WebSearch`, `mcp_fetch`, etc.) over `curl` when available. The URLs and patterns below work with any fetching method — the `curl` examples are just illustrative.
 
 ### 2a. Documentation Index (llms.txt)
 
@@ -77,7 +77,7 @@ Alternatively, you can start on `https://langfuse.com/docs` and explore the site
 
 ### 2b. Fetch Individual Pages as Markdown
 
-Any page listed in llms.txt can be fetched as markdown by appending `.md` to its path or by using Accept: text/markdown in the request headers. Use this when you know which page contains the information needed. Returns clean markdown with code examples and configuration details.
+Any page listed in llms.txt can be fetched as markdown by appending `.md` to its path or by using `Accept: text/markdown` in the request headers. Use this when you know which page contains the information needed. Returns clean markdown with code examples and configuration details.
 
 ```bash
 curl -s "https://langfuse.com/docs/observability/overview.md"

--- a/skills/langfuse/references/instrumentation.md
+++ b/skills/langfuse/references/instrumentation.md
@@ -39,7 +39,7 @@ Every trace should have these fundamentals:
 | Span hierarchy            | Are multi-step operations nested properly?                                               | Shows which step is slow or failing                    |
 | Correct observation types | Are generations marked as generations?                                                   | Enables model-specific analytics                       |
 | Sensitive data masked     | Is PII/confidential data excluded or masked?                                             | Prevents data leakage                                  |
-| Trace input/output        | Does the trace capture the full data being processed as input, and the result as output? | Enables debugging and understanding what was processed |
+| Trace input/output        | Does the trace capture meaningful input/output? Is input explicitly set to show only relevant data (e.g., user message), not all function args? | Makes traces readable in the UI and avoids leaking sensitive args |
 
 Framework integrations (OpenAI, LangChain, etc.) handle model name, tokens, and observation types automatically. Prefer integrations over manual instrumentation.
 
@@ -134,6 +134,7 @@ Learn more: https://langfuse.com/docs/tracing-features/sessions"
 | Flat traces                                    | Can't see which step failed                         | Use nested spans for distinct steps                                               |
 | Generic trace names                            | Hard to filter                                      | Use descriptive names: `chat-response`, `doc-summary`                             |
 | Logging sensitive data                         | Data leakage risk                                   | Mask PII before tracing                                                           |
+| Not explicitly setting input with `@observe`   | All function args become trace input (including API keys, configs) | Python: use `langfuse.update_current_span(input=...)`. JS/TS: use `updateActiveObservation({ input: ... })`. Set only the relevant input (e.g., user message) |
 | Manual instrumentation when integration exists | More code, less context                             | Use framework integration                                                         |
 | Langfuse import before env vars loaded         | Langfuse initializes with missing/wrong credentials | Import Langfuse AFTER loading environment variables (e.g., after `load_dotenv()`) |
 | Wrong import order with OpenAI                 | Langfuse can't patch the OpenAI client              | Import Langfuse and call its setup BEFORE importing OpenAI client                 |

--- a/skills/langfuse/references/user-feedback.md
+++ b/skills/langfuse/references/user-feedback.md
@@ -13,7 +13,20 @@ Docs: https://langfuse.com/docs/observability/features/user-feedback
 
 ### 1. Determine What Feedback to Capture
 
-If the user has asked for something specific, go with that. Otherwise, look at the application and suggest what makes sense.
+If the user has asked for something specific, go with that. Otherwise, look at the application and **present a few UX options** for how feedback could work, then ask the user which they prefer before implementing.
+
+Common UX patterns to suggest:
+
+| UX Pattern | Best for | How it works |
+|------------|----------|--------------|
+| Thumbs up/down | Chat apps, Q&A | Simple binary buttons next to each response |
+| Star rating (1–5) | Content generation, summaries | Star row or dropdown after each output |
+| "Was this helpful?" banner | Search, documentation assistants | Single yes/no prompt at the bottom of a response |
+| Regenerate / copy tracking | Any app with these actions | Implicit — log when users retry (negative signal) or copy output (positive signal) |
+| Free-text comment | Complex outputs, internal tools | Optional text field alongside a rating |
+| Report button | Any user-facing app | Flag icon to report bad/harmful responses |
+
+This table is not exhaustive — if the application suggests a different feedback pattern that fits better, propose that instead. Present 2–3 options that match the application's use case and ask the user which approach they'd like. This decision shapes everything downstream (score names, data types, frontend components), so it's important to align early.
 
 Feedback can be **explicit** (user rates via thumbs, stars, etc.) or **implicit** (derived from behavior like copying output, retrying, or escalating to support). Both are stored as scores. Explicit feedback requires the trace ID to reach the frontend; implicit feedback is logged server-side where the event already happens.
 


### PR DESCRIPTION
## Summary

- **Instrumentation**: update trace input/output baseline requirement to emphasize explicitly setting meaningful input (e.g., user message) rather than capturing all function args with `@observe`. Add common mistake entry with correct SDK methods (`update_current_span` / `updateActiveObservation`).
- **SKILL.md**: instruct agents to prefer native web fetch/search tools over `curl` for documentation access.
- **User feedback**: present concrete UX options (thumbs, stars, implicit tracking, etc.) and ask user which they prefer before implementing.