### PR TITLE
feat: add CLI documentation link to cli reference

### DIFF
--- a/skills/langfuse/references/cli.md
+++ b/skills/langfuse/references/cli.md
@@ -1,5 +1,7 @@
 # Langfuse CLI Reference
 
+Documentation: https://langfuse.com/docs/api-and-data-platform/features/cli
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a link to the [CLI documentation page](https://langfuse.com/docs/api-and-data-platform/features/cli) at the top of the CLI reference file