### PR TITLE
feat: pre-approve common read-only tools for langfuse skill

### DIFF
--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -1,6 +1,18 @@
 ---
 name: langfuse
 description: Interact with Langfuse and access its documentation. Use when needing to (1) query or modify Langfuse data programmatically via the CLI — traces, prompts, datasets, scores, sessions, and any other API resource, (2) look up Langfuse documentation, concepts, integration guides, or SDK usage, or (3) understand how any Langfuse feature works. This skill covers CLI-based API access (via npx) and multiple documentation retrieval methods.
+allowed-tools:
+  - WebFetch(domain:langfuse.com)
+  - Bash(curl *langfuse.com/*)
+  - Bash(npx langfuse-cli api __schema *)
+  - Bash(npx langfuse-cli api * --help *)
+  - Bash(npx langfuse-cli api * list *)
+  - Bash(npx langfuse-cli api * get *)
+  - Bash(bunx langfuse-cli api __schema *)
+  - Bash(bunx langfuse-cli api * --help *)
+  - Bash(bunx langfuse-cli api * list *)
+  - Bash(bunx langfuse-cli api * get *)
+  - Read(~/.claude/skills/langfuse/references/**)
 ---
 
 # Langfuse


### PR DESCRIPTION
## Summary

Adds an `allowed-tools` block to `skills/langfuse/SKILL.md` so the most common read-only operations the skill performs can run without per-call approval prompts.

Pre-approved:

- **Docs fetching** — `WebFetch(domain:langfuse.com)` and `Bash(curl *langfuse.com/*)` cover both fetch paths the skill uses (the curl pattern is intentionally fragile per the [permissions docs](https://code.claude.com/docs/en/permissions); non-langfuse curl falls through to a prompt)
- **CLI discovery** — `__schema` and `--help` for both `npx langfuse-cli` and `bunx langfuse-cli`
- **CLI reads** — `list` and `get` actions across any resource
- **Skill references** — `Read` access to `~/.claude/skills/langfuse/references/**` so the use-case-specific reference files load without prompts

Writes (`create`, `update`, `delete`) intentionally still prompt.

## Notes

- Patterns use trailing ` *` to cover bare commands, flags, and stderr redirects (`2>&1`) without breaking
- The Read pattern only covers the user-global install location. If the skill is later distributed as a project skill or plugin, additional Read patterns will need to be added for those locations