### PR TITLE
fix: avoid leaking LANGFUSE_SECRET_KEY into agent context

### DIFF
--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -65,7 +65,7 @@ export LANGFUSE_SECRET_KEY=sk-lf-...
 export LANGFUSE_HOST=https://cloud.langfuse.com # example for EU cloud. For US cloud it's us.cloud.langfuse.com, and can also be a self-hosted URL. The server must always be specified in order to access Langfuse.
 ```
 
-If not set, ask the user for their API keys (found in Langfuse UI → Settings → API Keys).
+If not set, ask the user to set them in their shell or a `.env` file (do not ask them to paste keys into chat for security reasons). Keys are found in Langfuse UI → Settings → API Keys.
 
 ### Detailed CLI Reference
 

--- a/skills/langfuse/references/prompt-migration.md
+++ b/skills/langfuse/references/prompt-migration.md
@@ -9,15 +9,15 @@ Migrate hardcoded prompts to Langfuse for version control, A/B testing, and depl
 
 ## Prerequisites
 
-Verify credentials before starting:
+Verify credentials are set before starting. Check existence only — never print the secret key, since the value would land in the agent's context and transcripts:
 
 ```bash
-echo $LANGFUSE_PUBLIC_KEY   # pk-...
-echo $LANGFUSE_SECRET_KEY   # sk-...
-echo $LANGFUSE_HOST         # https://cloud.langfuse.com or self-hosted
+[ -n "$LANGFUSE_PUBLIC_KEY" ] && echo "LANGFUSE_PUBLIC_KEY: set" || echo "LANGFUSE_PUBLIC_KEY: missing"
+[ -n "$LANGFUSE_SECRET_KEY" ] && echo "LANGFUSE_SECRET_KEY: set" || echo "LANGFUSE_SECRET_KEY: missing"
+[ -n "$LANGFUSE_HOST" ]       && echo "LANGFUSE_HOST: $LANGFUSE_HOST" || echo "LANGFUSE_HOST: missing"
 ```
 
-If not set, ask user to configure them first.
+If not set, ask the user to configure them in their shell or a `.env` file. Do not ask them to paste keys into chat.
 
 ## Migration Flow
 


### PR DESCRIPTION
## Summary

Addresses [#21](https://github.com/langfuse/skills/discussions/21) — two patterns in the langfuse skill could cause `LANGFUSE_SECRET_KEY` to land in the agent's transcript (and from there into LLM provider logs and persisted session files).

- **`references/prompt-migration.md`** — replaces `echo \$LANGFUSE_*` in the prerequisites with existence checks (`[ -n "\$VAR" ]`). The host is still printed since it isn't sensitive and is useful for EU/US/self-hosted debugging.
- **`SKILL.md`** — reworded the credential prompt to direct users to set keys in their shell or a `.env` file rather than paste them into chat.

The third concern in the discussion (`--curl` leaking the `Authorization` header) was verified against the current CLI — the header value is already truncated (`Basic cGs...WU=`), so no change is needed there.