### PR TITLE
feat: add Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "langfuse",
+  "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Langfuse",
+    "email": "support@langfuse.com"
+  },
+  "homepage": "https://langfuse.com",
+  "repository": "https://github.com/langfuse/skills",
+  "license": "MIT",
+  "keywords": [
+    "langfuse",
+    "llm",
+    "observability",
+    "tracing",
+    "prompt-management",
+    "evaluation"
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
+  "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "version": "1.0.0",
   "author": {
     "name": "Langfuse",


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/plugin.json` so the repo is installable as a first-class Claude Code plugin (via `claude --plugin-dir <path>` or, in a follow-up, a marketplace).
- Mirrors the existing `.cursor-plugin/plugin.json` metadata; Claude Code auto-discovers `skills/` from the plugin root, so no other layout changes are needed.
- Additive only — Cursor plugin, `npx skills add` CLI, and manual symlink installs are unaffected (they don't read `.claude-plugin/`).

## Notes
- The skill is namespaced as `/langfuse:langfuse` when installed as a plugin (vs. `/langfuse` when symlinked standalone). Worth mentioning in README later if we go the marketplace route.
- Reference: https://code.claude.com/docs/en/plugins