### PR TITLE
chore: remove redundant references read permission from langfuse skill

### DIFF
--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -12,7 +12,6 @@ allowed-tools:
   - Bash(bunx langfuse-cli api * --help *)
   - Bash(bunx langfuse-cli api * list *)
   - Bash(bunx langfuse-cli api * get *)
-  - Read(~/.claude/skills/langfuse/references/**)
 ---
 
 # Langfuse


### PR DESCRIPTION
## Summary

- Removes `Read(~/.claude/skills/langfuse/references/**)` from the `allowed-tools` list in `skills/langfuse/SKILL.md`
- Reading files within a skill's own directory is already pre-approved automatically, so this entry was redundant