### PR TITLE
docs: remove redundant 'When to Use' sections from skill references

### DIFF
--- a/skills/langfuse/references/instrumentation.md
+++ b/skills/langfuse/references/instrumentation.md
@@ -7,12 +7,6 @@ description: Instrument LLM applications with Langfuse tracing. Use when setting
 
 Instrument LLM applications with Langfuse tracing, following best practices and tailored to your use case.
 
-## When to Use
-
-- Setting up Langfuse in a new project
-- Auditing existing Langfuse instrumentation
-- Adding observability to LLM calls
-
 ## Workflow
 
 ### 1. Assess Current State

--- a/skills/langfuse/references/sdk-upgrade.md
+++ b/skills/langfuse/references/sdk-upgrade.md
@@ -7,12 +7,6 @@ description: Upgrade Langfuse SDKs from older versions to the latest. Use when m
 
 Assist users in upgrading their Langfuse SDK to the latest version. The Python and JS/TS SDKs share the same architectural changes but differ in syntax.
 
-## When to Use
-
-- User asks to upgrade/migrate their Langfuse SDK
-- User is on an older SDK version and encounters deprecated APIs
-- User wants to adopt the latest Langfuse features
-
 ## Migration Docs
 
 Always fetch the latest migration guide before starting — these pages are the source of truth:


### PR DESCRIPTION
## Summary

- Removed the `## When to Use` sections from `instrumentation.md` and `sdk-upgrade.md` reference files
- Trigger conditions for these skills already live in each file's front matter `description`, so the body sections were redundant