### PR TITLE
fix stale "prefer v2" tips that reference non-existent resources

### DIFF
--- a/skills/langfuse/references/cli.md
+++ b/skills/langfuse/references/cli.md
@@ -44,10 +44,9 @@ export LANGFUSE_HOST=https://cloud.langfuse.com
 
 - Use `--json` for machine-readable JSON output
 - Use `--curl` to preview the HTTP request without executing
-- Pagination: use `--limit` and `--page` on list endpoints
 - All list commands support filtering — check `<resource> <action> --help` for available options
-- Prefer `observations` over `legacy-observations-v1s` (the modern endpoint is exposed as `observations`; `legacy-observations-v1s` is the deprecated v1)
-- Prefer `metrics` over `legacy-metrics-v1s`
+- Prefer `observations` over `legacy-observations-v1s` — `observations` is the modern high-performance endpoint (cursor pagination, selective field groups); `legacy-observations-v1s` is the deprecated v1
+- Prefer `metrics` over `legacy-metrics-v1s` for the same reason
 - Prefer `scores` over `legacy-score-v1s` for list/get operations
-- The legacy `traces list` endpoint on Langfuse Cloud times out on broad queries — use `observations list` (with `--trace-id` if you need to traverse from a known trace) instead.
-  Server returns: *"This legacy endpoint can be slow. Please migrate to the high-performance Observations API v2."*
+- For broad trace queries, `traces list` can time out on Langfuse Cloud — use `observations list` (with `--trace-id` if you're traversing from a known trace) instead. See the [Observations API docs](https://langfuse.com/docs/api-and-data-platform/features/observations-api) for the v1 → v2 mapping.
+- Pagination: legacy v1 endpoints use `--limit` and `--page`; modern endpoints (`observations`, `metrics`, `scores`) use cursor-based pagination — pass `--limit`, then thread `meta.cursor` from the response into the next request's `--cursor`

--- a/skills/langfuse/references/cli.md
+++ b/skills/langfuse/references/cli.md
@@ -46,6 +46,8 @@ export LANGFUSE_HOST=https://cloud.langfuse.com
 - Use `--curl` to preview the HTTP request without executing
 - Pagination: use `--limit` and `--page` on list endpoints
 - All list commands support filtering — check `<resource> <action> --help` for available options
-- Prefer `observations-v2s` over `observations` — the v2 endpoint returns richer data
-- Prefer `metrics-v2s` over `metrics` — the v2 endpoint returns richer data
-- Prefer `score-v2s` over `scores` — the v1 `scores` resource only supports create/delete; use `score-v2s` for list and get operations
+- Prefer `observations` over `legacy-observations-v1s` (the modern endpoint is exposed as `observations`; `legacy-observations-v1s` is the deprecated v1)
+- Prefer `metrics` over `legacy-metrics-v1s`
+- Prefer `scores` over `legacy-score-v1s` for list/get operations
+- The legacy `traces list` endpoint on Langfuse Cloud times out on broad queries — use `observations list` (with `--trace-id` if you need to traverse from a known trace) instead.
+  Server returns: *"This legacy endpoint can be slow. Please migrate to the high-performance Observations API v2."*


### PR DESCRIPTION
When using the skill with Claude code I found the following problem. followed the guidelines and created a PR that should fix it:

## Problem

  `references/cli.md` advises preferring `observations-v2s`, `metrics-v2s`,
  and `score-v2s`, but none of those resource names exist in the current
  schema. Following the tips verbatim produces `error: unknown command`.

  Verified against `langfuse-cli` v3.175.0 / Langfuse Cloud US:

  $ npx langfuse-cli api __schema
  …
  - legacy-metrics-v1s (1 actions)
  - legacy-observations-v1s (2 actions)
  - legacy-score-v1s (2 actions)
  - metrics (1 actions)
  - observations (1 actions)
  - scores (2 actions)
  …

  The v2 endpoints are now exposed under the canonical names
  (`observations`, `metrics`, `scores`); the legacy v1 endpoints are
  explicitly prefixed `legacy-*-v1s`. The tips need to be inverted.

  ## Bonus tip

  Also added a note about the `traces list` Cloud timeout. Even with
  `--limit 3 --from-timestamp <15-min-ago>` the server responds:

  > *Your query could not be completed… This legacy endpoint can be slow.
  > Please migrate to the high-performance Observations API v2 at
  > /api/public/v2/observations.* — `"error": "Request timed out"`

  Pointing users at `observations list` (optionally with `--trace-id`)
  saves a wrong turn.

  ## Test

  - [x] Read-only doc change; no code paths touched.
  - [x] Verified resource names against live `__schema` output.