### PR TITLE
docs: use LANGFUSE_BASE_URL instead of LANGFUSE_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You need a Langfuse account ([cloud](https://cloud.langfuse.com) or [self-hosted
 ```bash
 export LANGFUSE_PUBLIC_KEY=pk-lf-...
 export LANGFUSE_SECRET_KEY=sk-lf-...
-export LANGFUSE_HOST=https://cloud.langfuse.com  # or https://us.cloud.langfuse.com, or self-hosted URL
+export LANGFUSE_BASE_URL=https://cloud.langfuse.com  # or https://us.cloud.langfuse.com, or self-hosted URL
 ```
 
 API keys are found in your Langfuse project under **Settings > API Keys**.

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -64,7 +64,7 @@ Set environment variables before making calls:
 ```bash
 export LANGFUSE_PUBLIC_KEY=pk-lf-...
 export LANGFUSE_SECRET_KEY=sk-lf-...
-export LANGFUSE_HOST=https://cloud.langfuse.com # example for EU cloud. For US cloud it's us.cloud.langfuse.com, and can also be a self-hosted URL. The server must always be specified in order to access Langfuse.
+export LANGFUSE_BASE_URL=https://cloud.langfuse.com # example for EU cloud. For US cloud it's us.cloud.langfuse.com, and can also be a self-hosted URL. The server must always be specified in order to access Langfuse.
 ```
 
 If not set, ask the user to set them in their shell or a `.env` file (do not ask them to paste keys into chat for security reasons). Keys are found in Langfuse UI → Settings → API Keys.

--- a/skills/langfuse/references/cli.md
+++ b/skills/langfuse/references/cli.md
@@ -37,7 +37,7 @@ Set environment variables:
 ```bash
 export LANGFUSE_PUBLIC_KEY=pk-lf-...
 export LANGFUSE_SECRET_KEY=sk-lf-...
-export LANGFUSE_HOST=https://cloud.langfuse.com  
+export LANGFUSE_BASE_URL=https://cloud.langfuse.com  
 ```
 
 ## Tips

--- a/skills/langfuse/references/error-analysis.md
+++ b/skills/langfuse/references/error-analysis.md
@@ -41,10 +41,10 @@ The guide describes the process. These notes cover the Langfuse-specific API and
 ```bash
 echo $LANGFUSE_PUBLIC_KEY   # pk-lf-...
 echo $LANGFUSE_SECRET_KEY   # sk-lf-...
-echo $LANGFUSE_HOST         # https://cloud.langfuse.com (EU), https://us.cloud.langfuse.com (US), https://jp.cloud.langfuse.com (JP) or self-hosted
+echo $LANGFUSE_BASE_URL     # https://cloud.langfuse.com (EU), https://us.cloud.langfuse.com (US), https://jp.cloud.langfuse.com (JP) or self-hosted
 ```
 
-If not set, check `.env` in the project root: `export $(grep -v '^#' .env | xargs)`. If `LANGFUSE_BASE_URL` is used instead of `LANGFUSE_HOST`, run `export LANGFUSE_HOST="$LANGFUSE_BASE_URL"`.
+If not set, check `.env` in the project root: `export $(grep -v '^#' .env | xargs)`. If `LANGFUSE_HOST` is used instead of `LANGFUSE_BASE_URL`, run `export LANGFUSE_BASE_URL="$LANGFUSE_HOST"`.
 
 ```bash
 AUTH=$(echo -n "${LANGFUSE_PUBLIC_KEY}:${LANGFUSE_SECRET_KEY}" | base64)
@@ -52,7 +52,7 @@ AUTH=$(echo -n "${LANGFUSE_PUBLIC_KEY}:${LANGFUSE_SECRET_KEY}" | base64)
 # Verify before proceeding
 STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
   -H "Authorization: Basic $AUTH" \
-  "${LANGFUSE_HOST}/api/public/projects")
+  "${LANGFUSE_BASE_URL}/api/public/projects")
 echo "Auth check: $STATUS"
 ```
 
@@ -73,7 +73,7 @@ If status is not `200`, stop and ask the user to check their credentials and hos
 |------|-------------|
 | EU cloud | `https://cloud.langfuse.com/project/<projectId>/annotation-queues/<queueId>` |
 | US cloud | `https://us.cloud.langfuse.com/project/<projectId>/annotation-queues/<queueId>` |
-| Self-hosted | `<LANGFUSE_HOST>/project/<projectId>/annotation-queues/<queueId>` |
+| Self-hosted | `<LANGFUSE_BASE_URL>/project/<projectId>/annotation-queues/<queueId>` |
 
 Instruction to give: *"Please open code the first ~50 examples. For each trace, write what you observe in the `open_coding` field (describe behaviour, don't diagnose root causes), then set `pass_fail_assessment` to Pass or Fail."*
 

--- a/skills/langfuse/references/prompt-migration.md
+++ b/skills/langfuse/references/prompt-migration.md
@@ -14,7 +14,7 @@ Verify credentials are set before starting. Check existence only — never print
 ```bash
 [ -n "$LANGFUSE_PUBLIC_KEY" ] && echo "LANGFUSE_PUBLIC_KEY: set" || echo "LANGFUSE_PUBLIC_KEY: missing"
 [ -n "$LANGFUSE_SECRET_KEY" ] && echo "LANGFUSE_SECRET_KEY: set" || echo "LANGFUSE_SECRET_KEY: missing"
-[ -n "$LANGFUSE_HOST" ]       && echo "LANGFUSE_HOST: $LANGFUSE_HOST" || echo "LANGFUSE_HOST: missing"
+[ -n "$LANGFUSE_BASE_URL" ]   && echo "LANGFUSE_BASE_URL: $LANGFUSE_BASE_URL" || echo "LANGFUSE_BASE_URL: missing"
 ```
 
 If not set, ask the user to configure them in their shell or a `.env` file. Do not ask them to paste keys into chat.


### PR DESCRIPTION
## Summary

Standardizes the skill docs on `LANGFUSE_BASE_URL`, matching the current Langfuse SDK ecosystem (Python and JS/TS SDK docs both use `LANGFUSE_BASE_URL`) and the Langfuse CLI's own resolution order, which checks `LANGFUSE_BASE_URL` before `LANGFUSE_HOST`.

`LANGFUSE_HOST` continues to work as a fallback in the CLI, so existing users aren't affected.

## Changes

- `README.md`, `SKILL.md`, `references/cli.md`, `references/prompt-migration.md` — swapped the env var name in credential examples.
- `references/error-analysis.md` — swapped the credentials example, the curl scripts (`${LANGFUSE_BASE_URL}`), the self-hosted URL pattern in the table, and reversed the fallback note (now: if a user has `LANGFUSE_HOST` set, export `LANGFUSE_BASE_URL` from it).

Left untouched: `references/user-feedback.md` uses `NEXT_PUBLIC_LANGFUSE_HOST`, which is a separate prefixed variable for the web SDK.

Closes #37