### PR TITLE
feat(langfuse): add CI/CD experiment gate guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ API keys are found in your Langfuse project under **Settings > API Keys**.
 Once installed, the agent will automatically use these skills when relevant — for example:
 
 - Setting up Langfuse tracing in a project
+- Setting up CI/CD experiment gates with `langfuse/experiment-action`
 - Auditing existing instrumentation
 - Migrating prompts to Langfuse prompt management
 - Querying traces, prompts, or datasets via the API

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: langfuse
-description: Interact with Langfuse and access its documentation. Use when needing to (1) query or modify Langfuse data programmatically via the CLI — traces, prompts, datasets, scores, sessions, and any other API resource, (2) look up Langfuse documentation, concepts, integration guides, or SDK usage, or (3) understand how any Langfuse feature works. This skill covers CLI-based API access (via npx) and multiple documentation retrieval methods.
+description: Interact with Langfuse and access its documentation. Use when needing to (1) query or modify Langfuse data programmatically via the CLI — traces, prompts, datasets, scores, sessions, and any other API resource, (2) look up Langfuse documentation, concepts, integration guides, or SDK usage, (3) set up Langfuse experiment CI/CD gates, or (4) understand how any Langfuse feature works. This skill covers CLI-based API access (via npx), CI/CD experiment setup, and multiple documentation retrieval methods.
 allowed-tools:
   - WebFetch(domain:langfuse.com)
   - Bash(curl *langfuse.com/*)
@@ -37,6 +37,7 @@ Follow these principles for ALL Langfuse work:
 - upgrading or migrating Langfuse SDKs to the latest version: references/sdk-upgrade.md
 - judge calibration (LLM-as-a-Judge reliability, simple accuracy checks, advanced split-based validation, confusion matrices, and metric ingestion): references/judge-calibration.md
 - systematic error analysis — reading traces, building failure taxonomy, deciding what to fix: references/error-analysis.md
+- setting up CI/CD experiment gates with `langfuse/experiment-action`: references/ci-cd.md
 - submitting feedback about this skill: references/skill-feedback.md
 
 

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -10,12 +10,10 @@ allowed-tools:
   - Bash(npx langfuse-cli api * --help *)
   - Bash(npx langfuse-cli api * list *)
   - Bash(npx langfuse-cli api * get *)
-  - Bash(npx langfuse-cli api score-v2s get-scores *)
   - Bash(bunx langfuse-cli api __schema *)
   - Bash(bunx langfuse-cli api * --help *)
   - Bash(bunx langfuse-cli api * list *)
   - Bash(bunx langfuse-cli api * get *)
-  - Bash(bunx langfuse-cli api score-v2s get-scores *)
 ---
 
 # Langfuse

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: langfuse
-description: Interact with Langfuse and access its documentation. Use when needing to (1) query or modify Langfuse data programmatically via the CLI — traces, prompts, datasets, scores, sessions, and any other API resource, (2) look up Langfuse documentation, concepts, integration guides, or SDK usage, (3) set up Langfuse experiment CI/CD gates, or (4) understand how any Langfuse feature works. This skill covers CLI-based API access (via npx), CI/CD experiment setup, and multiple documentation retrieval methods.
+description: Interact with Langfuse and access its documentation. Use when needing to (1) query or modify Langfuse data programmatically via the CLI — traces, prompts, datasets, scores, sessions, and any other API resource, (2) look up Langfuse documentation, concepts, integration guides, or SDK usage, or (3) understand how any Langfuse feature works. This skill covers CLI-based API access (via npx) and multiple documentation retrieval methods.
 allowed-tools:
   - WebFetch(domain:langfuse.com)
-  - WebFetch(domain:github.com)
   - Bash(curl *langfuse.com/*)
-  - Bash(curl *github.com/langfuse/experiment-action*)
   - Bash(npx langfuse-cli api __schema *)
   - Bash(npx langfuse-cli api * --help *)
   - Bash(npx langfuse-cli api * list *)

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -3,15 +3,19 @@ name: langfuse
 description: Interact with Langfuse and access its documentation. Use when needing to (1) query or modify Langfuse data programmatically via the CLI — traces, prompts, datasets, scores, sessions, and any other API resource, (2) look up Langfuse documentation, concepts, integration guides, or SDK usage, (3) set up Langfuse experiment CI/CD gates, or (4) understand how any Langfuse feature works. This skill covers CLI-based API access (via npx), CI/CD experiment setup, and multiple documentation retrieval methods.
 allowed-tools:
   - WebFetch(domain:langfuse.com)
+  - WebFetch(domain:github.com)
   - Bash(curl *langfuse.com/*)
+  - Bash(curl *github.com/langfuse/experiment-action*)
   - Bash(npx langfuse-cli api __schema *)
   - Bash(npx langfuse-cli api * --help *)
   - Bash(npx langfuse-cli api * list *)
   - Bash(npx langfuse-cli api * get *)
+  - Bash(npx langfuse-cli api score-v2s get-scores *)
   - Bash(bunx langfuse-cli api __schema *)
   - Bash(bunx langfuse-cli api * --help *)
   - Bash(bunx langfuse-cli api * list *)
   - Bash(bunx langfuse-cli api * get *)
+  - Bash(bunx langfuse-cli api score-v2s get-scores *)
 ---
 
 # Langfuse

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -67,7 +67,7 @@ export LANGFUSE_PUBLIC_KEY=pk-lf-...
 export LANGFUSE_SECRET_KEY=sk-lf-...
 export LANGFUSE_HOST=https://cloud.langfuse.com # example for EU cloud. For US cloud it's us.cloud.langfuse.com, and can also be a self-hosted URL. The server must always be specified in order to access Langfuse.
 ```
-
+If `LANGFUSE_BASE_URL` is used instead of `LANGFUSE_HOST`, run `export LANGFUSE_HOST="$LANGFUSE_BASE_URL"`.
 If not set, ask the user to set them in their shell or a `.env` file (do not ask them to paste keys into chat for security reasons). Keys are found in Langfuse UI → Settings → API Keys.
 
 ### Detailed CLI Reference

--- a/skills/langfuse/references/ci-cd.md
+++ b/skills/langfuse/references/ci-cd.md
@@ -5,104 +5,23 @@ description: Set up or extend agent regression checks / gating in GitHub Actions
 
 # Langfuse CI/CD
 
-## Workflow
+## Checklist
 
-### 1. Confirm GitHub and the Target Repository
+- [ ] Follow the [CI/CD docs page](https://langfuse.com/docs/evaluation/experiments/experiments-ci-cd) and the [langfuse/experiment-action README](https://github.com/langfuse/experiment-action)
+- [ ] Inspect whether the local repository is a GitHub repo. If not, `langfuse/experiment-action` is not applicable. Follow the guide for other [CI/CD systems](https://langfuse.com/docs/evaluation/experiments/experiments-ci-cd#other-cicd-systems) instead
+- [ ] Ask the user which [evaluators and run evaluators](https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk#evaluators) they want to set up
+- [ ] Ask the user if and when yes which regression thresholds they want to set
+- [ ] Confirm dataset existence and shape of the dataset items before writing code with the Langfuse CLI (see `references/cli.md`)
+  - `langfuse-cli api datasets list`
+  - `langfuse-cli api dataset-items list --dataset-name <dataset name> --limit 5`
+- [ ] Propose the user to verify the check by actually running the new CI check (e.g. by creating a pull request)
+- [ ] If the evaluator task uses a third-party dependency, add the necessary CI steps to install them
 
-1. Inspect the local repo with `git remote -v`, `git rev-parse --show-toplevel`, and existing `.github/workflows/` files.
-2. Determine whether the user is using GitHub. If yes, continue with `langfuse/experiment-action`. If not, do not use `langfuse/experiment-action` or `RunnerContext`; suggest a platform-native CI gate using Langfuse SDK experiments instead. Fetch the CI/CD docs and look for the "Other CI/CD systems" / Pytest-Vitest assertion pattern: `https://langfuse.com/docs/evaluation/experiments/experiments-ci-cd#other-cicd-systems`, plus SDK details: `https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk`.
-3. Determine which repository should own the check. In monorepos or split app/evals repos, ask before editing if the answer is not obvious.
-
-### 2. Gather Gate Requirements
-
-Ask only for missing information that cannot be inferred from the repo. Collect:
-
-- Trigger: `pull_request`, `workflow_dispatch`, `push` to specific branches, `release` with `types: [published]`, or a combination.
-- Langfuse dataset name and optional dataset version.
-- Langfuse base URL if not the default cloud host.
-- Existing experiment script path, or whether to create one.
-- If creating a script: Python or TypeScript/JavaScript, and the application task to run for each dataset item.
-- Item-level evaluators the user actually wants, for example exact match, accuracy, factuality, conciseness, LLM-as-judge, or a custom rule.
-- Whether run-level evaluators are needed, which aggregate metric should gate CI, and which condition should count as a regression.
-- Required extra secrets for the experiment task, such as model provider API keys.
-- Whether the user will set GitHub secrets themselves or wants you to set them with `gh secret set`.
-
-Never ask the user to paste secrets into chat.
-
-### 3. Validate the Dataset and Design the Experiment
-
-First inspect a few dataset items with the Langfuse CLI (see `references/cli.md`) so the task and evaluators match the actual `input`, `expected_output`, and metadata fields. Confirm the script reads the right fields, handles missing expected outputs, and maps any item metadata needed by evaluators. `expected_output` may be an object such as `{"answer": "London"}` rather than a string; evaluators must extract the relevant field instead of comparing the full object.
-
-Choose evaluator types deliberately:
-
-- Use exact match for canonical short answers with stable formatting.
-- Use LLM-as-judge, rubric, semantic, or custom evaluators for free-form answers, reasoning, style, conciseness, or partially correct responses.
-- If the user wants an aggregate gate, add a run-level evaluator that computes the metric the regression policy will read.
-
-### 4. Validate or Create the Experiment Script
-
-If the user already has a script, verify:
-
-- The script path and file type match what the action expects (the action README's script contract lists supported extensions and the `experiment_path` input).
-- It exposes the `experiment(context)` entry point the action calls and runs the experiment through the action-provided context, so dataset, dataset version, metadata, and the Langfuse client come from the workflow rather than being hardcoded.
-- It signals a regression (raising `RegressionError` with the result, per the docs) when the user-defined condition is met.
-- Secrets are read from environment variables, not hardcoded.
-
-If creating a script, integrate with existing app code when available. If the app entry point is unclear, create the smallest useful skeleton with explicit TODOs at the task boundary and tell the user what they must connect.
-
-For the recommended Python and TypeScript script shape, fetch and use the canonical examples in the Langfuse docs instead of relying on copied snippets here:
-
-- CI/CD script contract and `RegressionError` examples: `https://langfuse.com/docs/evaluation/experiments/experiments-ci-cd#experiment-definition`
-- Evaluator and run-level evaluator patterns: `https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk#evaluators`
-- Full action input/output behavior: `https://github.com/langfuse/experiment-action#script-contract`
-
-### 5. Calibrate the Regression Gate
-
-- Do not set thresholds blindly. Run the experiment once against a known-good baseline, inspect the item-level and run-level scores, then set the threshold below the healthy baseline with enough slack for expected variance.
-- Small datasets have coarse score granularity. With 3 items, each item is worth 33 percentage points, so thresholds between `0.67` and `1.0` may be misleading or impossible to satisfy reliably.
-- Read back the run and its scores with the Langfuse CLI (see `references/cli.md`) to inspect item-level and run-level score names and values before fixing a threshold.
-
-### 6. Add or Update the GitHub Actions Workflow
-
-The workflow and secrets sections below are GitHub Actions-specific. For GitLab, CircleCI, Jenkins, or other CI systems, reuse the dataset/evaluator/threshold design above, but implement the gate as a standalone SDK script or test that exits non-zero on regression and uses the platform's native secrets/triggers.
-
-- Prefer `.github/workflows/langfuse-experiment.yml` unless the repo has a clear existing workflow for evaluation gates.
-- Fetch the current README from `https://github.com/langfuse/experiment-action` before pinning the action. Prefer SHA-pinning with a human-readable version comment, matching the action README pattern.
-- Include only the runtime setup required by the experiment script:
-    - Python scripts: add `actions/setup-python`.
-    - TypeScript/JavaScript scripts: add `actions/setup-node`.
-    - The action can install Langfuse SDK defaults itself; check the action README for the current default SDK versions before overriding.
-    - If the experiment needs project/provider dependencies, add the repo's normal dependency file such as `requirements.txt` or `package.json`, run the normal install command before the action, and set `should_skip_sdk_installation: "true"` only when that dependency file also includes the required Langfuse SDK dependencies.
-- For the recommended workflow shape and current action inputs, use the canonical examples instead of copying a stale workflow snippet:
-    - CI/CD workflow guide: `https://langfuse.com/docs/evaluation/experiments/experiments-ci-cd#github-actions`
-    - Action README and inputs: `https://github.com/langfuse/experiment-action#usage`
-- Adjust permissions:
-    - `pull-requests: write` is needed for PR comments.
-    - `actions: read` lets comments link to the specific job logs.
-    - If not commenting on PRs, omit `github_token`, set `should_comment_on_pr: "false"`, and reduce permissions.
-- If the user wants regressions reported without failing CI, set `should_fail_on_regression: "false"`.
-
-### 7. Configure Secrets
-
-Required GitHub secrets:
-    - `LANGFUSE_PUBLIC_KEY`
-    - `LANGFUSE_SECRET_KEY`
-    - Optional secrets depend on the experiment task, for example `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`. Add them under `env:` on the action step.
-
-If using `gh secret set` to configure them, verify `gh auth status` first, and source values from the local environment rather than chat. If a value is exported locally, pass it via `--body "$NAME"`; if not, have the user run the command in their own terminal and paste the secret at the stdin prompt. Never ask the user to paste secret values into chat.
-
-### 8. Verification
-
-Before finishing, prefer an end-to-end workflow run over local-only validation. Ask before creating PRs, triggering CI, or running paid model experiments unless the user already requested it:
-
-- If the trigger is `pull_request`, create or update a test PR so the workflow runs in GitHub Actions.
-- If the repo has no default/base branch yet, create an initial empty commit on the intended default branch before relying on PR-triggered verification.
-- If the trigger is `workflow_dispatch`, run it with `gh workflow run <workflow-file> --ref <branch>` and inspect the run.
-- If the trigger is `push` or `release`, agree with the user on a safe branch/tag/release to exercise.
-- Use `gh run list`, `gh run view --log`, and the GitHub Checks UI to confirm the action completed, posted PR comments when configured, and failed or passed according to the regression policy.
-- Only run the full experiment when credentials are configured and the user understands any model/API cost implications.
-- Use local checks as preflight validation: YAML syntax or `actionlint`, the repo formatter, and the repo typecheck/lint where available.
-- Summarize the workflow run URL or run ID, any secrets still missing, and the exact trigger/dataset/regression condition configured.
+### GitHub specific checklist
+- [ ] Ask the user how they want the [workflow to be triggered](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
+- [ ] If available, use the `gh` CLI to check secret existence / set secrets for:
+      - Langfuse credentials
+      - Credentials required by the evaluator task (e.g. OpenAI or Anthropic API keys)
 
 ## Common Issues
 

--- a/skills/langfuse/references/ci-cd.md
+++ b/skills/langfuse/references/ci-cd.md
@@ -73,7 +73,7 @@ For the recommended Python and TypeScript script shape, fetch and use the canoni
     ```bash
     npx langfuse-cli api datasets get-get-runs --dataset-name <dataset> --json  # find the dataset run ID
     npx langfuse-cli api scores list --dataset-run-id <dataset-run-id> --json  # inspect score names/values for that run
-    npx langfuse-cli api scores-v-2 --help  # use if the needed score data is not exposed by `scores list`
+    npx langfuse-cli api score-v2s get-scores --limit 20 --json  # use if the needed score data is not exposed by `scores list`
     ```
 
 ### 6. Add or Update the GitHub Actions Workflow

--- a/skills/langfuse/references/ci-cd.md
+++ b/skills/langfuse/references/ci-cd.md
@@ -73,7 +73,7 @@ For the recommended Python and TypeScript script shape, fetch and use the canoni
     ```bash
     npx langfuse-cli api datasets get-get-runs --dataset-name <dataset> --json  # find the dataset run ID
     npx langfuse-cli api scores list --dataset-run-id <dataset-run-id> --json  # inspect score names/values for that run
-    npx langfuse-cli api score-v2s get-scores --limit 20 --json  # use if the needed score data is not exposed by `scores list`
+    npx langfuse-cli api scores --help  # inspect current score commands and filters if `scores list` is insufficient
     ```
 
 ### 6. Add or Update the GitHub Actions Workflow

--- a/skills/langfuse/references/ci-cd.md
+++ b/skills/langfuse/references/ci-cd.md
@@ -5,8 +5,6 @@ description: Set up or extend agent regression checks / gating in GitHub Actions
 
 # Langfuse CI/CD
 
-Use this reference when setting up a Langfuse experiment gate in CI/CD to catch regressions before they reach production / main branch.
-
 ## Workflow
 
 ### 1. Confirm GitHub and the Target Repository
@@ -33,13 +31,7 @@ Never ask the user to paste secrets into chat.
 
 ### 3. Validate the Dataset and Design the Experiment
 
-First validate the dataset item shape with the Langfuse CLI so the task and evaluators match the actual `input`, `expected_output`, and metadata fields. Ensure `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and non-default `LANGFUSE_HOST` are available before running it:
-
-```bash
-npx langfuse-cli api dataset-items list --dataset-name <dataset> --limit 5 --json
-```
-
-Use the returned items to confirm the script reads the right fields, handles missing expected outputs, and maps any item metadata needed by evaluators. `expected_output` may be an object such as `{"answer": "London"}` rather than a string; evaluators must extract the relevant field instead of comparing the full object.
+First inspect a few dataset items with the Langfuse CLI (see `references/cli.md`) so the task and evaluators match the actual `input`, `expected_output`, and metadata fields. Confirm the script reads the right fields, handles missing expected outputs, and maps any item metadata needed by evaluators. `expected_output` may be an object such as `{"answer": "London"}` rather than a string; evaluators must extract the relevant field instead of comparing the full object.
 
 Choose evaluator types deliberately:
 
@@ -51,10 +43,9 @@ Choose evaluator types deliberately:
 
 If the user already has a script, verify:
 
-- The path matches `experiment_path` and has a supported extension: `.py`, `.ts`, `.js`, `.mjs`, or `.cjs`.
-- The script defines `experiment(context)` in Python or exports `experiment(context)` in TypeScript/JavaScript.
-- The script uses the action-provided context via `context.run_experiment(...)` in Python or `context.runExperiment(...)` in TypeScript/JavaScript so dataset, dataset version, metadata, and the Langfuse client come from the workflow.
-- The script raises `RegressionError` with the experiment result when the user-defined regression condition is met.
+- The script path and file type match what the action expects (the action README's script contract lists supported extensions and the `experiment_path` input).
+- It exposes the `experiment(context)` entry point the action calls and runs the experiment through the action-provided context, so dataset, dataset version, metadata, and the Langfuse client come from the workflow rather than being hardcoded.
+- It signals a regression (raising `RegressionError` with the result, per the docs) when the user-defined condition is met.
 - Secrets are read from environment variables, not hardcoded.
 
 If creating a script, integrate with existing app code when available. If the app entry point is unclear, create the smallest useful skeleton with explicit TODOs at the task boundary and tell the user what they must connect.
@@ -69,12 +60,7 @@ For the recommended Python and TypeScript script shape, fetch and use the canoni
 
 - Do not set thresholds blindly. Run the experiment once against a known-good baseline, inspect the item-level and run-level scores, then set the threshold below the healthy baseline with enough slack for expected variance.
 - Small datasets have coarse score granularity. With 3 items, each item is worth 33 percentage points, so thresholds between `0.67` and `1.0` may be misleading or impossible to satisfy reliably.
-- To read back runs and scores with the CLI:
-    ```bash
-    npx langfuse-cli api datasets get-get-runs --dataset-name <dataset> --json  # find the dataset run ID
-    npx langfuse-cli api scores list --dataset-run-id <dataset-run-id> --json  # inspect score names/values for that run
-    npx langfuse-cli api scores --help  # inspect current score commands and filters if `scores list` is insufficient
-    ```
+- Read back the run and its scores with the Langfuse CLI (see `references/cli.md`) to inspect item-level and run-level score names and values before fixing a threshold.
 
 ### 6. Add or Update the GitHub Actions Workflow
 
@@ -85,7 +71,7 @@ The workflow and secrets sections below are GitHub Actions-specific. For GitLab,
 - Include only the runtime setup required by the experiment script:
     - Python scripts: add `actions/setup-python`.
     - TypeScript/JavaScript scripts: add `actions/setup-node`.
-    - The action can install Langfuse SDK defaults itself. The action README currently defaults to Python SDK `4.6.0` and JS SDK `5.3.0`; check current docs before overriding.
+    - The action can install Langfuse SDK defaults itself; check the action README for the current default SDK versions before overriding.
     - If the experiment needs project/provider dependencies, add the repo's normal dependency file such as `requirements.txt` or `package.json`, run the normal install command before the action, and set `should_skip_sdk_installation: "true"` only when that dependency file also includes the required Langfuse SDK dependencies.
 - For the recommended workflow shape and current action inputs, use the canonical examples instead of copying a stale workflow snippet:
     - CI/CD workflow guide: `https://langfuse.com/docs/evaluation/experiments/experiments-ci-cd#github-actions`
@@ -103,26 +89,7 @@ Required GitHub secrets:
     - `LANGFUSE_SECRET_KEY`
     - Optional secrets depend on the experiment task, for example `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`. Add them under `env:` on the action step.
 
-If using `gh` to set secrets:
-
-1. Verify `gh auth status`.
-2. Prefer reading values from local environment variables, not chat.
-3. If the values are already exported locally, use `--body "$NAME"`:
-
-```bash
-gh secret set LANGFUSE_PUBLIC_KEY --repo OWNER/REPO --body "$LANGFUSE_PUBLIC_KEY"
-gh secret set LANGFUSE_SECRET_KEY --repo OWNER/REPO --body "$LANGFUSE_SECRET_KEY"
-gh secret set ANTHROPIC_API_KEY --repo OWNER/REPO --body "$ANTHROPIC_API_KEY"
-gh secret list --repo OWNER/REPO
-```
-
-If a value is not exported locally, tell the user to run the stdin form in their own terminal and paste the secret when prompted:
-
-```bash
-gh secret set ANTHROPIC_API_KEY --repo OWNER/REPO
-```
-
-The pasted value goes to `gh` via stdin. Do not ask the user to paste secret values into chat.
+If using `gh secret set` to configure them, verify `gh auth status` first, and source values from the local environment rather than chat. If a value is exported locally, pass it via `--body "$NAME"`; if not, have the user run the command in their own terminal and paste the secret at the stdin prompt. Never ask the user to paste secret values into chat.
 
 ### 8. Verification
 
@@ -146,4 +113,4 @@ Before finishing, prefer an end-to-end workflow run over local-only validation. 
 | Workflow secrets or action inputs are wrong | Verify `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `langfuse_base_url`, and provider secrets exist in the target repo/environment and are passed to the action step. |
 | Forked PR cannot access secrets | GitHub restricts secret access for forked PRs. Document the limitation or choose a trusted trigger such as internal PR, trusted-branch `push`, or `workflow_dispatch`. |
 | No default/base branch exists | Create an initial empty commit on the intended default branch before trying to verify a PR-triggered workflow. |
-| Script fails reading dataset fields | Re-run `npx langfuse-cli api dataset-items list --dataset-name <dataset> --limit 5 --json`, inspect `input`, `expected_output`, and metadata, and extract fields from object-shaped outputs explicitly. |
+| Script fails reading dataset fields | Re-inspect the dataset items with the Langfuse CLI, check `input`, `expected_output`, and metadata, and extract fields from object-shaped outputs explicitly. |

--- a/skills/langfuse/references/ci-cd.md
+++ b/skills/langfuse/references/ci-cd.md
@@ -1,0 +1,149 @@
+---
+name: langfuse-ci-cd
+description: Set up or extend agent regression checks / gating in GitHub Actions CI/CD using `langfuse/experiment-action`.
+---
+
+# Langfuse CI/CD
+
+Use this reference when setting up a Langfuse experiment gate in CI/CD to catch regressions before they reach production / main branch.
+
+## Workflow
+
+### 1. Confirm GitHub and the Target Repository
+
+1. Inspect the local repo with `git remote -v`, `git rev-parse --show-toplevel`, and existing `.github/workflows/` files.
+2. Determine whether the user is using GitHub. If yes, continue with `langfuse/experiment-action`. If not, do not use `langfuse/experiment-action` or `RunnerContext`; suggest a platform-native CI gate using Langfuse SDK experiments instead. Fetch the CI/CD docs and look for the "Other CI/CD systems" / Pytest-Vitest assertion pattern: `https://langfuse.com/docs/evaluation/experiments/experiments-ci-cd#other-cicd-systems`, plus SDK details: `https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk`.
+3. Determine which repository should own the check. In monorepos or split app/evals repos, ask before editing if the answer is not obvious.
+
+### 2. Gather Gate Requirements
+
+Ask only for missing information that cannot be inferred from the repo. Collect:
+
+- Trigger: `pull_request`, `workflow_dispatch`, `push` to specific branches, `release` with `types: [published]`, or a combination.
+- Langfuse dataset name and optional dataset version.
+- Langfuse base URL if not the default cloud host.
+- Existing experiment script path, or whether to create one.
+- If creating a script: Python or TypeScript/JavaScript, and the application task to run for each dataset item.
+- Item-level evaluators the user actually wants, for example exact match, accuracy, factuality, conciseness, LLM-as-judge, or a custom rule.
+- Whether run-level evaluators are needed, which aggregate metric should gate CI, and which condition should count as a regression.
+- Required extra secrets for the experiment task, such as model provider API keys.
+- Whether the user will set GitHub secrets themselves or wants you to set them with `gh secret set`.
+
+Never ask the user to paste secrets into chat.
+
+### 3. Validate the Dataset and Design the Experiment
+
+First validate the dataset item shape with the Langfuse CLI so the task and evaluators match the actual `input`, `expected_output`, and metadata fields. Ensure `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and non-default `LANGFUSE_HOST` are available before running it:
+
+```bash
+npx langfuse-cli api dataset-items list --dataset-name <dataset> --limit 5 --json
+```
+
+Use the returned items to confirm the script reads the right fields, handles missing expected outputs, and maps any item metadata needed by evaluators. `expected_output` may be an object such as `{"answer": "London"}` rather than a string; evaluators must extract the relevant field instead of comparing the full object.
+
+Choose evaluator types deliberately:
+
+- Use exact match for canonical short answers with stable formatting.
+- Use LLM-as-judge, rubric, semantic, or custom evaluators for free-form answers, reasoning, style, conciseness, or partially correct responses.
+- If the user wants an aggregate gate, add a run-level evaluator that computes the metric the regression policy will read.
+
+### 4. Validate or Create the Experiment Script
+
+If the user already has a script, verify:
+
+- The path matches `experiment_path` and has a supported extension: `.py`, `.ts`, `.js`, `.mjs`, or `.cjs`.
+- The script defines `experiment(context)` in Python or exports `experiment(context)` in TypeScript/JavaScript.
+- The script uses the action-provided context via `context.run_experiment(...)` in Python or `context.runExperiment(...)` in TypeScript/JavaScript so dataset, dataset version, metadata, and the Langfuse client come from the workflow.
+- The script raises `RegressionError` with the experiment result when the user-defined regression condition is met.
+- Secrets are read from environment variables, not hardcoded.
+
+If creating a script, integrate with existing app code when available. If the app entry point is unclear, create the smallest useful skeleton with explicit TODOs at the task boundary and tell the user what they must connect.
+
+For the recommended Python and TypeScript script shape, fetch and use the canonical examples in the Langfuse docs instead of relying on copied snippets here:
+
+- CI/CD script contract and `RegressionError` examples: `https://langfuse.com/docs/evaluation/experiments/experiments-ci-cd#experiment-definition`
+- Evaluator and run-level evaluator patterns: `https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk#evaluators`
+- Full action input/output behavior: `https://github.com/langfuse/experiment-action#script-contract`
+
+### 5. Calibrate the Regression Gate
+
+- Do not set thresholds blindly. Run the experiment once against a known-good baseline, inspect the item-level and run-level scores, then set the threshold below the healthy baseline with enough slack for expected variance.
+- Small datasets have coarse score granularity. With 3 items, each item is worth 33 percentage points, so thresholds between `0.67` and `1.0` may be misleading or impossible to satisfy reliably.
+- To read back runs and scores with the CLI:
+    ```bash
+    npx langfuse-cli api datasets get-get-runs --dataset-name <dataset> --json  # find the dataset run ID
+    npx langfuse-cli api scores list --dataset-run-id <dataset-run-id> --json  # inspect score names/values for that run
+    npx langfuse-cli api scores-v-2 --help  # use if the needed score data is not exposed by `scores list`
+    ```
+
+### 6. Add or Update the GitHub Actions Workflow
+
+The workflow and secrets sections below are GitHub Actions-specific. For GitLab, CircleCI, Jenkins, or other CI systems, reuse the dataset/evaluator/threshold design above, but implement the gate as a standalone SDK script or test that exits non-zero on regression and uses the platform's native secrets/triggers.
+
+- Prefer `.github/workflows/langfuse-experiment.yml` unless the repo has a clear existing workflow for evaluation gates.
+- Fetch the current README from `https://github.com/langfuse/experiment-action` before pinning the action. Prefer SHA-pinning with a human-readable version comment, matching the action README pattern.
+- Include only the runtime setup required by the experiment script:
+    - Python scripts: add `actions/setup-python`.
+    - TypeScript/JavaScript scripts: add `actions/setup-node`.
+    - The action can install Langfuse SDK defaults itself. The action README currently defaults to Python SDK `4.6.0` and JS SDK `5.3.0`; check current docs before overriding.
+    - If the experiment needs project/provider dependencies, add the repo's normal dependency file such as `requirements.txt` or `package.json`, run the normal install command before the action, and set `should_skip_sdk_installation: "true"` only when that dependency file also includes the required Langfuse SDK dependencies.
+- For the recommended workflow shape and current action inputs, use the canonical examples instead of copying a stale workflow snippet:
+    - CI/CD workflow guide: `https://langfuse.com/docs/evaluation/experiments/experiments-ci-cd#github-actions`
+    - Action README and inputs: `https://github.com/langfuse/experiment-action#usage`
+- Adjust permissions:
+    - `pull-requests: write` is needed for PR comments.
+    - `actions: read` lets comments link to the specific job logs.
+    - If not commenting on PRs, omit `github_token`, set `should_comment_on_pr: "false"`, and reduce permissions.
+- If the user wants regressions reported without failing CI, set `should_fail_on_regression: "false"`.
+
+### 7. Configure Secrets
+
+Required GitHub secrets:
+    - `LANGFUSE_PUBLIC_KEY`
+    - `LANGFUSE_SECRET_KEY`
+    - Optional secrets depend on the experiment task, for example `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`. Add them under `env:` on the action step.
+
+If using `gh` to set secrets:
+
+1. Verify `gh auth status`.
+2. Prefer reading values from local environment variables, not chat.
+3. If the values are already exported locally, use `--body "$NAME"`:
+
+```bash
+gh secret set LANGFUSE_PUBLIC_KEY --repo OWNER/REPO --body "$LANGFUSE_PUBLIC_KEY"
+gh secret set LANGFUSE_SECRET_KEY --repo OWNER/REPO --body "$LANGFUSE_SECRET_KEY"
+gh secret set ANTHROPIC_API_KEY --repo OWNER/REPO --body "$ANTHROPIC_API_KEY"
+gh secret list --repo OWNER/REPO
+```
+
+If a value is not exported locally, tell the user to run the stdin form in their own terminal and paste the secret when prompted:
+
+```bash
+gh secret set ANTHROPIC_API_KEY --repo OWNER/REPO
+```
+
+The pasted value goes to `gh` via stdin. Do not ask the user to paste secret values into chat.
+
+### 8. Verification
+
+Before finishing, prefer an end-to-end workflow run over local-only validation. Ask before creating PRs, triggering CI, or running paid model experiments unless the user already requested it:
+
+- If the trigger is `pull_request`, create or update a test PR so the workflow runs in GitHub Actions.
+- If the repo has no default/base branch yet, create an initial empty commit on the intended default branch before relying on PR-triggered verification.
+- If the trigger is `workflow_dispatch`, run it with `gh workflow run <workflow-file> --ref <branch>` and inspect the run.
+- If the trigger is `push` or `release`, agree with the user on a safe branch/tag/release to exercise.
+- Use `gh run list`, `gh run view --log`, and the GitHub Checks UI to confirm the action completed, posted PR comments when configured, and failed or passed according to the regression policy.
+- Only run the full experiment when credentials are configured and the user understands any model/API cost implications.
+- Use local checks as preflight validation: YAML syntax or `actionlint`, the repo formatter, and the repo typecheck/lint where available.
+- Summarize the workflow run URL or run ID, any secrets still missing, and the exact trigger/dataset/regression condition configured.
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| `gh` is missing or not authenticated | Install the GitHub CLI if needed, then run `gh auth status` and `gh auth login` before using `gh secret` or `gh workflow` commands. |
+| Local Langfuse environment variables are not set | Set `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_HOST` locally before using `langfuse-cli`; do not ask the user to paste secret values into chat. |
+| Workflow secrets or action inputs are wrong | Verify `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `langfuse_base_url`, and provider secrets exist in the target repo/environment and are passed to the action step. |
+| Forked PR cannot access secrets | GitHub restricts secret access for forked PRs. Document the limitation or choose a trusted trigger such as internal PR, trusted-branch `push`, or `workflow_dispatch`. |
+| No default/base branch exists | Create an initial empty commit on the intended default branch before trying to verify a PR-triggered workflow. |
+| Script fails reading dataset fields | Re-run `npx langfuse-cli api dataset-items list --dataset-name <dataset> --limit 5 --json`, inspect `input`, `expected_output`, and metadata, and extract fields from object-shaped outputs explicitly. |


### PR DESCRIPTION
## Summary

- Add a Langfuse CI/CD reference for setting up experiment regression gates with `langfuse/experiment-action`.
- Cover the practical setup flow: CI platform detection, dataset shape validation, evaluator selection, threshold calibration, workflow setup, secrets, verification, and common issues.
- Link the reference from the existing `langfuse` skill and README, and bump both plugin manifests to `1.1.0` for the new published capability.

## Linear

- [LFE-9689](https://linear.app/langfuse/issue/LFE-9689/skill-for-cicd)

## Review Focus

- Whether the plugin version bump from `1.0.1` to `1.1.0` matches the repo's published-skill rules.