### PR TITLE
feat: add Claude Code marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "langfuse",
+  "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation",
+  "owner": {
+    "name": "Langfuse",
+    "url": "https://github.com/langfuse"
+  },
+  "plugins": [
+    {
+      "name": "langfuse",
+      "source": "./",
+      "description": "Skills for working with Langfuse — tracing, prompt management, and evaluation",
+      "version": "1.1.0",
+      "author": { "name": "Langfuse", "email": "support@langfuse.com" },
+      "homepage": "https://langfuse.com",
+      "license": "MIT",
+      "category": "development",
+      "keywords": ["langfuse", "llm", "observability", "tracing", "prompt-management", "evaluation"]
+    }
+  ]
+}


### PR DESCRIPTION
This is an embarrassingly minor edit — adds `.claude-plugin/marketplace.json` so this repo can be referenced as an external Claude Code plugin from any marketplace:

```
/plugin install langfuse
```

The existing `plugin.json` already has all the metadata — this just adds the marketplace wrapper needed for external discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)