### PR TITLE
docs(langfuse): add required_access metadata to reference frontmatter

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -8,6 +8,12 @@
 
 - **Put "when to use" guidance in exactly two places:** a one-line entry in the `## Use case specific references` list in `SKILL.md`, and the `description` in the reference file's frontmatter. Nowhere else — no prose routing section, no "when to use" section in the reference body. *A reference body is read only after the agent already chose to open it, so routing text there is dead weight.*
 
+- **Every reference file's frontmatter must declare a `metadata.required_access` list** — the kinds of access an agent needs to execute that reference. Use only these tokens, and reuse them consistently across files:
+  - `CODEBASE` — reads or edits the user's source code
+  - `LANGFUSE_PROJECT_INTERFACE` — reaches the Langfuse project via CLI / API / MCP commands
+  - `LANGFUSE_PROJECT_SCRIPT` — runs SDK code that connects to the Langfuse backend (needs network)
+  - `GITHUB` — operates on GitHub via the `gh` CLI
+
 - **In the reference file, less is more.** Add only what's useful or what an agent couldn't infer on its own.
 
 - **Never commit code.** Link to the relevant Langfuse docs page so the agent fetches current code; use pseudo-code only for logic-specific bits. *Committed code goes stale.*

--- a/skills/langfuse/references/ci-cd.md
+++ b/skills/langfuse/references/ci-cd.md
@@ -1,6 +1,12 @@
 ---
 name: langfuse-ci-cd
 description: Set up or extend agent regression checks / gating in GitHub Actions CI/CD using `langfuse/experiment-action`.
+metadata:
+  required_access:
+    - CODEBASE
+    - LANGFUSE_PROJECT_INTERFACE
+    - LANGFUSE_PROJECT_SCRIPT
+    - GITHUB
 ---
 
 # Langfuse CI/CD

--- a/skills/langfuse/references/cli.md
+++ b/skills/langfuse/references/cli.md
@@ -1,3 +1,11 @@
+---
+name: langfuse-cli
+description: Langfuse CLI usage reference — install, resource/action discovery, credentials, and common usage tips for `langfuse-cli`. Use for further tips on using the Langfuse CLI.
+metadata:
+  required_access:
+    - LANGFUSE_PROJECT_INTERFACE
+---
+
 # Langfuse CLI Reference
 
 Documentation: https://langfuse.com/docs/api-and-data-platform/features/cli

--- a/skills/langfuse/references/error-analysis.md
+++ b/skills/langfuse/references/error-analysis.md
@@ -8,6 +8,9 @@ description: Deep-dive error analysis of an LLM pipeline or AI application using
   errors", "build a failure taxonomy", "what's going wrong with my pipeline", or any
   request to systematically inspect, annotate, or score Langfuse traces. If the user
   is trying to understand or improve the quality of an AI system's outputs, use this skill.
+metadata:
+  required_access:
+    - LANGFUSE_PROJECT_INTERFACE
 ---
 
 # Error Analysis

--- a/skills/langfuse/references/instrumentation.md
+++ b/skills/langfuse/references/instrumentation.md
@@ -1,6 +1,10 @@
 ---
 name: langfuse-observability
 description: Instrument LLM applications with Langfuse tracing. Use when setting up Langfuse, adding observability to LLM calls, or auditing existing instrumentation.
+metadata:
+  required_access:
+    - CODEBASE
+    - LANGFUSE_PROJECT_SCRIPT
 ---
 
 # Langfuse Observability

--- a/skills/langfuse/references/judge-calibration.md
+++ b/skills/langfuse/references/judge-calibration.md
@@ -2,6 +2,10 @@
 name: langfuse-judge-calibration
 description: Calibrate and validate LLM-as-a-Judge evaluators against dataset ground truth. Runs the judge prompt as a Langfuse dataset experiment, compares judge outputs with dataset item expected outputs, and reports simple accuracy or advanced confusion-matrix metrics. Use this guide whenever a user asks if their LLM judge is actually useful,
 aligned with human judgment, or safe to trust for monitoring decisions.
+metadata:
+  required_access:
+    - CODEBASE
+    - LANGFUSE_PROJECT_SCRIPT
 ---
 
 # Judge Calibration (LLM-as-a-Judge)

--- a/skills/langfuse/references/prompt-migration.md
+++ b/skills/langfuse/references/prompt-migration.md
@@ -1,6 +1,10 @@
 ---
 name: langfuse-prompt-migration
 description: Migrate hardcoded prompts to Langfuse for version control and deployment-free iteration. Use when user wants to externalize prompts, move prompts to Langfuse, or set up prompt management.
+metadata:
+  required_access:
+    - CODEBASE
+    - LANGFUSE_PROJECT_SCRIPT
 ---
 
 # Langfuse Prompt Migration

--- a/skills/langfuse/references/sdk-upgrade.md
+++ b/skills/langfuse/references/sdk-upgrade.md
@@ -1,6 +1,10 @@
 ---
 name: langfuse-sdk-upgrade
 description: Upgrade Langfuse SDKs from older versions to the latest. Use when migrating Python SDK v2/v3 to v4, or JS/TS SDK v3/v4 to v5.
+metadata:
+  required_access:
+    - CODEBASE
+    - LANGFUSE_PROJECT_SCRIPT
 ---
 
 # Langfuse SDK Upgrade Guide

--- a/skills/langfuse/references/skill-feedback.md
+++ b/skills/langfuse/references/skill-feedback.md
@@ -1,6 +1,9 @@
 ---
 name: langfuse-skill-feedback
 description: Submit feedback about the Langfuse skill to its maintainers via GitHub Discussions. Use when the user indicates the skill gave incorrect guidance, is missing information, or could be improved.
+metadata:
+  required_access:
+    - GITHUB
 ---
 
 # Skill Feedback

--- a/skills/langfuse/references/user-feedback.md
+++ b/skills/langfuse/references/user-feedback.md
@@ -1,6 +1,10 @@
 ---
 name: langfuse-user-feedback
 description: Wires up user feedback (thumbs up/down, ratings, comments) from an application's frontend to Langfuse scores. Use when user wants to capture end-user feedback, add ratings to traces, or connect user complaints to Langfuse.
+metadata:
+  required_access:
+    - CODEBASE
+    - LANGFUSE_PROJECT_SCRIPT
 ---
 
 # User Feedback


### PR DESCRIPTION
Adds a `metadata.required_access` list to the frontmatter of every Langfuse skill reference file, declaring which kinds of access an agent needs to execute that reference.

## Access tokens

| Token | Meaning |
|-------|---------|
| `CODEBASE` | reads/edits the user's source code |
| `LANGFUSE_PROJECT_INTERFACE` | reaches the Langfuse project via CLI / API / MCP commands |
| `LANGFUSE_PROJECT_SCRIPT` | runs SDK code that connects to the Langfuse backend (needs network) |
| `GITHUB` | operates on GitHub via the `gh` CLI |

The interface/script split distinguishes a Langfuse CLI/API/MCP command from running an SDK script that has to reach the Langfuse backend.

## Per-file `required_access`

| File | required_access |
|------|-----------------|
| `ci-cd.md` | CODEBASE, LANGFUSE_PROJECT_INTERFACE, LANGFUSE_PROJECT_SCRIPT, GITHUB |
| `cli.md` | LANGFUSE_PROJECT_INTERFACE |
| `error-analysis.md` | LANGFUSE_PROJECT_INTERFACE |
| `instrumentation.md` | CODEBASE, LANGFUSE_PROJECT_SCRIPT |
| `judge-calibration.md` | CODEBASE, LANGFUSE_PROJECT_SCRIPT |
| `prompt-migration.md` | CODEBASE, LANGFUSE_PROJECT_SCRIPT |
| `sdk-upgrade.md` | CODEBASE, LANGFUSE_PROJECT_SCRIPT |
| `skill-feedback.md` | GITHUB |
| `user-feedback.md` | CODEBASE, LANGFUSE_PROJECT_SCRIPT |

`cli.md` previously had no frontmatter, so it also gains a `name` and `description` block consistent with its siblings.