### PR TITLE
docs(langfuse): make plans specify explicit SDK version

### DIFF
--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -25,7 +25,7 @@ Follow these principles for ALL Langfuse work:
 1. **Documentation First**: NEVER implement based on memory. Always fetch current docs before writing code (Langfuse updates frequently). See the section below on how to access documentation.
 2. **CLI for Data Access**: Use `langfuse-cli` when querying/modifying Langfuse data. See the section below on how to use the CLI. 
 3. **Best Practices by Use Case**: Check the relevant reference file below for use-case-specific guidelines before implementing
-4. **Use latest Langfuse versions**: Unless the user specified otherwise or there's a good reason, always use the latest version of Langfuse SDKs/APIs.
+4. **Use latest Langfuse versions**: Unless the user specified otherwise or there's a good reason, always use the latest version of Langfuse SDKs/APIs. Even if you're only creating a plan for another agent to execute, be explicit about the exact version to use.
 
 
 ## Use case specific references


### PR DESCRIPTION
Extends the "Use latest Langfuse versions" core principle so that plans handed off to another agent explicitly state the exact SDK/API version to use. This prevents an executing agent without the skill from falling back to an outdated version based on memory.