### PR TITLE
docs(langfuse): clarify changelog posts are not for implementation

### DIFF
--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -121,7 +121,7 @@ Returns a JSON response with:
   - `title`: page title
   - `source.content`: array of relevant text excerpts from the page
 
-Search is a great fallback if you cannot find the relevant pages or need more context. Especially useful when debugging issues as all GitHub Issues and Discussions are also indexed. Responses can be large — extract only the relevant portions.
+Search is a great fallback if you cannot find the relevant pages or need more context. Especially useful when debugging issues as all GitHub Issues and Discussions are also indexed. Responses can be large — extract only the relevant portions. Note that changelog posts may also surface here: use them only to confirm a feature exists, never to implement from — their examples may be outdated, so always implement from the docs and API/SDK reference.
 
 ### Documentation Workflow
 


### PR DESCRIPTION
Changelog posts can surface in Langfuse doc search results, but their examples may be outdated. This adds a caveat to the search section of the langfuse skill: changelog posts should only be used to confirm a feature exists, and implementation should always come from the docs and API/SDK reference.