### PR TITLE
fix: add Codex plugin legal links

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -35,6 +35,8 @@
       "Migrate prompts into Langfuse."
     ],
     "websiteURL": "https://langfuse.com",
+    "privacyPolicyURL": "https://langfuse.com/privacy",
+    "termsOfServiceURL": "https://langfuse.com/terms",
     "brandColor": "#F97316",
     "logo": "./assets/logo.png"
   }


### PR DESCRIPTION
## Summary

- Add `privacyPolicyURL` to the Codex plugin manifest.
- Add `termsOfServiceURL` to the Codex plugin manifest.

## Why

The public plugin submission checklist expects privacy policy and terms URLs to be present and aligned with the publisher identity.

## Validation

- Ran `python3 /Users/jannik/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py /Users/jannik/Documents/GitHub/skills`
- Verified the remote branch differs from `main` only by `.codex-plugin/plugin.json` with two added lines.