### PR TITLE
feat(langfuse): add v4 platform migration workflow

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",
@@ -32,7 +32,8 @@
     "defaultPrompt": [
       "Set up Langfuse tracing in this app.",
       "Inspect Langfuse traces for recent failures.",
-      "Migrate prompts into Langfuse."
+      "Migrate prompts into Langfuse.",
+      "Prepare this application and its Langfuse project for the v4 platform migration. Fetch and follow https://raw.githubusercontent.com/langfuse/skills/main/skills/langfuse/references/v4-project-migration.md and https://raw.githubusercontent.com/langfuse/skills/main/skills/langfuse/references/sdk-upgrade.md. Implement and validate applicable code and project changes, then report UI-only or blocked steps."
     ],
     "websiteURL": "https://langfuse.com",
     "privacyPolicyURL": "https://langfuse.com/privacy",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Once installed, the agent will automatically use these skills when relevant — 
 - Setting up Langfuse tracing in a project
 - Setting up CI/CD experiment gates with `langfuse/experiment-action`
 - Auditing existing instrumentation
+- Preparing an application and Langfuse project for the v4 platform migration
 - Migrating prompts to Langfuse prompt management
 - Querying traces, prompts, or datasets via the API
 - Looking up Langfuse docs, SDK usage, or integration guides

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -37,6 +37,7 @@ Follow these principles for ALL Langfuse work:
 - capturing user feedback (thumbs, ratings, implicit signals) as scores on traces: references/user-feedback.md
 - further tips on using the Langfuse CLI: references/cli.md
 - upgrading or migrating Langfuse SDKs to the latest version: references/sdk-upgrade.md
+- preparing an application and Langfuse project for the v4 platform migration: references/sdk-upgrade.md and references/v4-project-migration.md
 - judge calibration (LLM-as-a-Judge reliability, simple accuracy checks, advanced split-based validation, confusion matrices, and metric ingestion): references/judge-calibration.md
 - systematic error analysis — reading traces, building failure taxonomy, deciding what to fix: references/error-analysis.md
 - setting up CI/CD experiment gates with `langfuse/experiment-action`: references/ci-cd.md

--- a/skills/langfuse/references/sdk-upgrade.md
+++ b/skills/langfuse/references/sdk-upgrade.md
@@ -1,179 +1,74 @@
 ---
 name: langfuse-sdk-upgrade
-description: Upgrade Langfuse SDKs from older versions to the latest. Use when migrating Python SDK v2/v3 to v4, or JS/TS SDK v3/v4 to v5.
+description: Upgrade Langfuse SDKs and instrumentation to current versions. Use when migrating Python SDK v2/v3 to v4, JS/TS SDK v3/v4 to v5, or preparing application code for the Langfuse v4 platform.
 metadata:
   required_access:
     - CODEBASE
     - LANGFUSE_PROJECT_SCRIPT
 ---
 
-# Langfuse SDK Upgrade Guide
+# Langfuse SDK upgrade
 
-Assist users in upgrading their Langfuse SDK to the latest version. The Python and JS/TS SDKs share the same architectural changes but differ in syntax.
+## Sources of truth
 
-## Migration Docs
+Fetch the applicable pages in full before editing. Do not implement from this file or memory alone.
 
-Always fetch the latest migration guide before starting — these pages are the source of truth:
+- [Langfuse v4 overview](https://langfuse.com/docs/v4)
+- [Python v3 to v4](https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4)
+- [JS/TS v4 to v5](https://langfuse.com/docs/observability/sdk/upgrade-path/js-v4-to-v5)
+- [Direct OpenTelemetry setup](https://langfuse.com/integrations/native/opentelemetry)
+- [Observations API](https://langfuse.com/docs/api-and-data-platform/features/observations-api)
+- [Metrics API](https://langfuse.com/docs/metrics/features/metrics-api)
 
-- **Python (v3 → v4):** https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4
-- **JS/TS (v4 → v5):** https://langfuse.com/docs/observability/sdk/upgrade-path/js-v4-to-v5
+Use the exact minimum versions and migration requirements in the current docs. Prefer the latest stable release in the required major unless the repository has an explicit compatibility constraint.
 
-Fetch the relevant page as markdown before implementing any changes:
+## Workflow
 
-```bash
-curl -s "https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4.md"
-curl -s "https://langfuse.com/docs/observability/sdk/upgrade-path/js-v4-to-v5.md"
-```
+### 1. Inventory before editing
 
-## Upgrade Checklist
+- Find every Langfuse SDK, integration package, direct OpenTelemetry exporter, initialization site, instrumentation wrapper, trace-update call, and direct Langfuse API call across the whole repository.
+- Record the installed and resolved versions for every application/package. Include lockfiles, workspace overrides, and peer dependencies.
+- Identify tests, examples, workers, and scripts that initialize Langfuse independently; do not assume the main application is the only ingestion path.
+- If this is part of the v4 platform migration, also follow `references/v4-project-migration.md` and use its active-evaluator migration contract to drive the instrumentation changes below.
 
-Work through each item in order. Skip items that don't apply to the user's codebase.
+### 2. Upgrade the ingestion path
 
-### Both SDKs
+- Update dependencies with the repository's package manager and follow every applicable item in the current SDK migration guide.
+- For direct OpenTelemetry ingestion, apply the current v4 ingestion header and attribute-propagation requirements from the docs.
+- Preserve deliberate custom span-export behavior. Verify whether the application relies on non-LLM spans before accepting a new default span filter.
+- Replace removed or deprecated tracing APIs using the current guide. Do not retain deprecated trace input/output setters unless an active legacy trace evaluator still needs them during a staged cutover.
+- Keep correlating attributes inside the documented propagation scope so the target observations receive the attributes used by filters and analytics.
 
-- [ ] **Update the SDK package** to the latest version
-- [ ] **Audit span filtering**: Non-LLM spans (HTTP, DB, queues) no longer export by default. If the user relied on these, configure a custom `should_export_span` / `shouldExportSpan` filter
-- [ ] **Replace `update_current_trace()` / `updateActiveTrace()`**: Split into three calls:
-  - `propagate_attributes()` / `propagateAttributes()` for correlating attributes (`user_id`, `session_id`, `tags`, `metadata`, `trace_name`)
-  - `set_current_trace_io()` / `setActiveTraceIO()` for input/output (deprecated — prefer setting I/O on root observation directly)
-  - `set_current_trace_as_public()` / `setActiveTraceAsPublic()` for public flag
-- [ ] **Replace `.update_trace()` / `.updateTrace()`** on observation objects (same decomposition as above)
-- [ ] **Update API namespace references**: `observations_v_2` / `observationsV2` → `observations`, `score_v_2` / `scoreV2` → `scores`, `metrics_v_2` / `metricsV2` → `metrics`. Legacy v1 APIs moved to `api.legacy.*`
-- [ ] **Validate metadata format**: Must be `dict[str, str]` / `Record<string, string>` with values ≤200 characters
-- [ ] **Move `release` and `environment`** from code parameters to environment variables (`LANGFUSE_RELEASE`, `LANGFUSE_TRACING_ENVIRONMENT`)
-- [ ] **Enable debug logging** during migration to catch issues (`debug=True` in Python, `LANGFUSE_DEBUG="true"` in JS/TS)
-- [ ] **Test trace hierarchies** to verify no spans are unexpectedly dropped
+### 3. Make observation evaluators self-contained
 
-### Python-specific
+For every active legacy evaluator being replaced:
 
-- [ ] **Replace `start_span()` / `start_generation()`** with `start_observation()` (use `as_type="generation"` for generations)
-- [ ] **Replace `start_as_current_span()` / `start_as_current_generation()`** with `start_as_current_observation()`
-- [ ] **Replace dataset `item.run()`** with `dataset.run_experiment(name=..., task=...)`
-- [ ] **Remove `CallbackHandler(update_trace=...)`** parameter — use `propagate_attributes()` wrapper instead
-- [ ] **Upgrade to Pydantic v2** — the SDK now requires it. Use `pydantic.v1` compatibility shim if migrating gradually
-- [ ] **Update removed types**: `TraceMetadata`, `ObservationParams` removed from `langfuse.types`. Import `MapValue`, `ModelUsage`, `PromptClient` from `langfuse.model`
+- Choose one stable target observation by name/type and confirm it exists in representative traces.
+- Put the complete evaluation payload on that observation. Observation evaluators can map only that observation's input, output, metadata, and tool calls; they do not read sibling or child observations.
+- When judging an end-to-end application or agent invocation, use a root observation that records the overall input/output and any additional context the judge requires.
+- Ensure trace-level attributes used by evaluator filters are propagated onto the target observation.
+- Keep the payload intentional and minimal. Do not copy an entire trace into metadata when the evaluator needs only a small subset.
 
-### JS/TS-specific
+### 4. Replace deprecated API usage
 
-- [ ] **Update LangChain `CallbackHandler`** — `traceMetadata` now requires string values; internal behavior uses `propagateAttributes()` instead of direct trace updates
-- [ ] **Update OpenAI integration** — `traceMethod` wrapper now uses `propagateAttributes()` internally; wrap entire execution in `propagateAttributes()` if relying on parent attribute inheritance
+- Search both SDK resource namespaces and raw HTTP paths; include generated clients, fixtures, shell scripts, dashboards, and data pipelines.
+- Use the current SDK migration guide and API docs to replace transitional aliases and legacy Observations, Scores, or Metrics routes.
+- Check deployment availability before changing a self-hosted client to an endpoint that is Cloud-only or not yet available in that deployment.
+- Update pagination, selected field groups, filters, and response parsing together with the endpoint. A path-only replacement is not a complete migration.
 
-## Key API Changes Reference
+### 5. Verify
 
-### Correlating attributes (both SDKs)
+- Run the repository's focused formatting, type, lint, and test checks.
+- Exercise every changed ingestion path with representative application behavior. Confirm observation hierarchy, target observation input/output/context, propagated attributes, and absence of unexpected dropped spans.
+- If Langfuse project access is available, inspect the resulting observations and verify that each new evaluator rule matches the intended observation and can populate every variable.
+- Do not claim live verification when credentials or a runnable environment are unavailable. Report the exact remaining check.
 
-**Before:**
-```python
-# Python
-langfuse.update_current_trace(name="trace-name", user_id="user-123", session_id="session-abc", tags=["tag1"])
-```
-```typescript
-// JS/TS
-updateActiveTrace({ name: "trace-name", userId: "user-123", sessionId: "session-456", tags: ["prod"] });
-```
+## Completion report
 
-**After:**
-```python
-# Python
-from langfuse import propagate_attributes
+Report:
 
-with propagate_attributes(trace_name="trace-name", user_id="user-123", session_id="session-abc", tags=["tag1"]):
-    result = call_llm("hello")
-```
-```typescript
-// JS/TS
-import { propagateAttributes } from "langfuse";
-
-await propagateAttributes(
-  { traceName: "trace-name", userId: "user-123", sessionId: "session-456", tags: ["prod"] },
-  async () => { /* traced code */ }
-);
-```
-
-### Span/Generation creation (Python)
-
-**Before:**
-```python
-langfuse.start_span(name="x")
-langfuse.start_generation(name="x", model="gpt-4")
-```
-
-**After:**
-```python
-langfuse.start_observation(name="x")
-langfuse.start_observation(name="x", as_type="generation", model="gpt-4")
-```
-
-### Dataset experiments (Python)
-
-**Before:**
-```python
-for item in dataset.items:
-    with item.run(run_name="my-run") as span:
-        result = my_llm(item.input)
-        span.update(output=result)
-```
-
-**After:**
-```python
-def my_task(*, item, **kwargs):
-    return my_llm(item.input)
-
-dataset.run_experiment(name="my-run", task=my_task)
-```
-
-### Span filtering (both SDKs)
-
-To restore pre-upgrade "export all" behavior:
-
-```python
-# Python
-langfuse = Langfuse(should_export_span=lambda span: True)
-```
-```typescript
-// JS/TS
-const spanProcessor = new LangfuseSpanProcessor({ shouldExportSpan: () => true });
-```
-
-To extend defaults with custom scopes:
-
-```python
-# Python
-from langfuse.span_filter import is_default_export_span
-
-langfuse = Langfuse(
-    should_export_span=lambda span: (
-        is_default_export_span(span)
-        or span.instrumentation_scope.name.startswith("my_framework")
-    )
-)
-```
-```typescript
-// JS/TS
-import { isDefaultExportSpan } from "@langfuse/otel";
-
-shouldExportSpan: ({ otelSpan }) =>
-  isDefaultExportSpan(otelSpan) || otelSpan.instrumentationScope.name.startsWith("my_framework")
-```
-
-## Common Pitfalls
-
-| Pitfall | Impact | Fix |
-| --- | --- | --- |
-| Dropping intermediate spans via filtering | Breaks trace trees — child spans become orphaned | Use `is_default_export_span` as base and only add/remove specific scopes |
-| Metadata with non-string values | Values silently coerced or dropped | Ensure all metadata values are strings ≤200 characters |
-| Setting attributes outside `propagate_attributes()` callback | Attributes don't attach to observations | Wrap all traced code inside the callback |
-| Using deprecated `set_current_trace_io()` for new code | Will be removed in future versions | Set input/output directly on the root observation |
-| Forgetting Pydantic v2 upgrade (Python) | Import errors or runtime failures | Upgrade Pydantic or use `pydantic.v1` shim |
-| `release`/`environment` still passed as parameters | Silently ignored | Use `LANGFUSE_RELEASE` and `LANGFUSE_TRACING_ENVIRONMENT` env vars |
-| LangChain/OpenAI attribute propagation direction changed | Attributes propagate downward only, not upward to parent traces | Wrap outer call in `propagate_attributes()` |
-
-## Best Practices
-
-1. **Always fetch the migration docs first** — they are the canonical source and may have been updated since this guide was written
-2. **Enable debug logging during migration** to surface dropped spans and trace hierarchy issues
-3. **Use `propagate_attributes()` as the primary mechanism** for setting trace-level correlating attributes
-4. **Set input/output on root observations directly** rather than using deprecated trace-level setters
-5. **Compose custom span filters** with `is_default_export_span` / `isDefaultExportSpan` to extend defaults rather than replacing them entirely
-6. **Test thoroughly** — run the application with debug logging, check the Langfuse UI for missing or orphaned spans, verify metadata appears correctly
-7. **Migrate incrementally** — upgrade the SDK first, fix breaking changes, then adopt new patterns
+- exact SDK/package versions before and after
+- instrumentation and API call sites changed
+- active legacy evaluators that still temporarily require trace input/output
+- verification run and observed result
+- project or UI actions that remain

--- a/skills/langfuse/references/sdk-upgrade.md
+++ b/skills/langfuse/references/sdk-upgrade.md
@@ -29,7 +29,7 @@ Use the exact minimum versions and migration requirements in the current docs. P
 - Find every Langfuse SDK, integration package, direct OpenTelemetry exporter, initialization site, instrumentation wrapper, trace-update call, and direct Langfuse API call across the whole repository.
 - Record the installed and resolved versions for every application/package. Include lockfiles, workspace overrides, and peer dependencies.
 - Identify tests, examples, workers, and scripts that initialize Langfuse independently; do not assume the main application is the only ingestion path.
-- If this is part of the v4 platform migration, also follow `references/v4-project-migration.md` and use its active-evaluator migration contract to drive the instrumentation changes below.
+- If this is part of the v4 platform migration, also follow `references/v4-project-migration.md`; do not infer evaluator requirements during a standalone SDK upgrade.
 
 ### 2. Upgrade the ingestion path
 
@@ -38,29 +38,20 @@ Use the exact minimum versions and migration requirements in the current docs. P
 - Preserve deliberate custom span-export behavior. Verify whether the application relies on non-LLM spans before accepting a new default span filter.
 - Replace removed or deprecated tracing APIs using the current guide. Do not retain deprecated trace input/output setters unless an active legacy trace evaluator still needs them during a staged cutover.
 - Keep correlating attributes inside the documented propagation scope so the target observations receive the attributes used by filters and analytics.
+- For a v4 platform migration only, implement the code handoff from the active-evaluator migration contract in `references/v4-project-migration.md`: put the required evaluation context on its selected target observation and propagate the attributes used by its filters. Keep evaluator selection, mapping, and cutover decisions in the project workflow.
 
-### 3. Make observation evaluators self-contained
-
-For every active legacy evaluator being replaced:
-
-- Choose one stable target observation by name/type and confirm it exists in representative traces.
-- Put the complete evaluation payload on that observation. Observation evaluators can map only that observation's input, output, metadata, and tool calls; they do not read sibling or child observations.
-- When judging an end-to-end application or agent invocation, use a root observation that records the overall input/output and any additional context the judge requires.
-- Ensure trace-level attributes used by evaluator filters are propagated onto the target observation.
-- Keep the payload intentional and minimal. Do not copy an entire trace into metadata when the evaluator needs only a small subset.
-
-### 4. Replace deprecated API usage
+### 3. Replace deprecated API usage
 
 - Search both SDK resource namespaces and raw HTTP paths; include generated clients, fixtures, shell scripts, dashboards, and data pipelines.
 - Use the current SDK migration guide and API docs to replace transitional aliases and legacy Observations, Scores, or Metrics routes.
 - Check deployment availability before changing a self-hosted client to an endpoint that is Cloud-only or not yet available in that deployment.
 - Update pagination, selected field groups, filters, and response parsing together with the endpoint. A path-only replacement is not a complete migration.
 
-### 5. Verify
+### 4. Verify
 
 - Run the repository's focused formatting, type, lint, and test checks.
 - Exercise every changed ingestion path with representative application behavior. Confirm observation hierarchy, target observation input/output/context, propagated attributes, and absence of unexpected dropped spans.
-- If Langfuse project access is available, inspect the resulting observations and verify that each new evaluator rule matches the intended observation and can populate every variable.
+- For a v4 platform migration, inspect the resulting observations and verify the project workflow's evaluator contract when project access is available.
 - Do not claim live verification when credentials or a runnable environment are unavailable. Report the exact remaining check.
 
 ## Completion report
@@ -69,6 +60,6 @@ Report:
 
 - exact SDK/package versions before and after
 - instrumentation and API call sites changed
-- active legacy evaluators that still temporarily require trace input/output
+- for a v4 platform migration, evaluator-contract code changes and any legacy evaluator that still temporarily requires trace input/output
 - verification run and observed result
 - project or UI actions that remain

--- a/skills/langfuse/references/v4-project-migration.md
+++ b/skills/langfuse/references/v4-project-migration.md
@@ -1,0 +1,88 @@
+---
+name: langfuse-v4-project-migration
+description: Prepare a Langfuse project for the v4 platform by inventorying active evaluation rules, migrating legacy trace and dataset evaluators to observation and experiment targets, and moving exports to the enriched observation schema.
+metadata:
+  required_access:
+    - LANGFUSE_PROJECT_INTERFACE
+---
+
+# Langfuse v4 project migration
+
+Use this as the canonical project-side workflow. A coding agent should combine its output with the SDK upgrade workflow; the Langfuse in-app agent can execute the project steps and produce the same code handoff.
+
+## Sources of truth
+
+Fetch the applicable pages before taking action:
+
+- [Langfuse v4 overview](https://langfuse.com/docs/v4)
+- [Evaluator migration guide](https://langfuse.com/faq/all/llm-as-a-judge-migration)
+- [Observation evaluator context](https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge#observation-evaluator-context)
+- [Evaluators API](https://api.reference.langfuse.com/#tag/unstableevaluators)
+- [Evaluation Rules API](https://api.reference.langfuse.com/#tag/unstableevaluationrules)
+- [Blob storage export migration](https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage#export-source-fast-preview)
+- [Export field reference](https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-vs-legacy-differences)
+- [Mixpanel export migration](https://langfuse.com/integrations/analytics/mixpanel#export-source-fast-preview-langfuse-v4)
+- [PostHog export migration](https://langfuse.com/integrations/analytics/posthog#export-source-fast-preview-langfuse-v4)
+
+Discover the current API or tool schema before writes; the evaluator endpoints are unstable.
+
+## 1. Inventory active evaluation rules
+
+- Confirm the project, host, and whether it is Cloud or self-hosted.
+- Page through all available evaluators and evaluation rules. Inspect each referenced evaluator definition, not only its name.
+- Migrate rules whose effective `status` is `active`. Report paused/inactive rules separately; do not reactivate or migrate them unless requested.
+- Do not infer that the project has no legacy rules from the public list alone. Verify which targets the interface returns; if it omits legacy trace or dataset rules, use the UI check below.
+- Open the [Evaluators UI](https://cloud.langfuse.com/project/~/evals) and check for active rows marked **Legacy** whenever the interface cannot list those targets. In the in-app agent, redirect the user there. Treat this confirmation as required before declaring the project ready.
+
+## 2. Build an evaluator migration contract
+
+For every active legacy rule, record:
+
+| Field         | Required decision                                                                            |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| Existing rule | Name, evaluator, active status, filters, sampling, and variable mappings                     |
+| New target    | Trace to one observation; dataset/dataset run to experiment                                  |
+| Selector      | Stable observation name/type plus any propagated trace-attribute filters                     |
+| Mapping       | Every evaluator variable mapped exactly once to a supported source and optional JSONPath     |
+| Required data | Exact input, output, metadata, or tool-call fields that must exist on the target observation |
+| Code handoff  | Missing observation fields or attributes that the coding agent must add                      |
+| Cutover       | How the new rule will be verified before the legacy rule is disabled                         |
+
+- Inspect representative observations instead of guessing the target or data shape.
+- Use observation sources for live rules. Experiment rules may additionally use expected output and experiment-item metadata; confirm the current schema before writing.
+- Observation evaluators see only the matched observation. If the evaluator needs an end-to-end request, response, or summary assembled from multiple steps, target a root observation and require the application to write that context onto it.
+- Rebuild filters and mappings deliberately. Do not assume the UI upgrade wizard semantically preserves a legacy rule.
+
+## 3. Create and cut over successor rules
+
+- Reuse the existing evaluator definition when it remains valid. Create a new evaluator version only when the prompt, output definition, or variable contract must change.
+- Update an existing successor rule instead of creating a duplicate with the same name.
+- Create the observation or experiment successor disabled first when the interface supports it. Validate its target, filters, mappings, sampling, and evaluator-variable coverage against real project data.
+- Enable the successor only after the user approves the write. Verify it on newly ingested data; public evaluation rules are live-ingestion rules and do not perform historical backfills.
+- Compare resulting scores and execution logs. Keep the legacy rule available for rollback until the successor is proven.
+- Disable the active legacy rule in the UI after verification. Do not delete legacy rules or historical scores by default.
+- Re-list rules and re-check the UI. Completion requires no unintended active legacy trace/dataset rule and an active verified successor for every migrated rule.
+
+If the available project interface cannot read or update a legacy rule, provide the exact [Evaluators UI](https://cloud.langfuse.com/project/~/evals) action and retain it as an explicit blocker rather than claiming completion.
+
+## 4. Migrate exports
+
+- Inventory configured Blob Storage, Mixpanel, PostHog, and other export integrations in **Project Settings > Integrations**.
+- For Blob Storage, inspect or update the integration through the API when organization-scoped credentials and the current schema are available. Otherwise direct the user to [Blob Storage settings](https://cloud.langfuse.com/project/~/settings/integrations/blobstorage).
+- For Mixpanel and PostHog, use the UI and the linked migration guides. Do not claim an API migration path that the current interface does not provide.
+- Prefer the documented dual-export transition: enable legacy plus enriched observations, update and validate downstream consumers against the field reference, then switch to enriched observations only.
+- Do not overwrite bucket credentials, schedules, prefixes, file formats, field groups, or integration secrets while changing the export source.
+- Treat the downstream consumer update as part of the migration. A source toggle without validating queries, joins, dashboards, and field parsing is incomplete.
+
+## 5. Report readiness
+
+Return one row per area with `ready`, `changed`, `manual action`, or `blocked`:
+
+- SDK and instrumentation code handoff
+- active trace-to-observation evaluator migrations
+- active dataset-to-experiment evaluator migrations
+- deprecated API code handoff
+- Blob Storage and analytics export migrations
+- verification and rollback status
+
+Include direct UI links and the evaluator migration contract so an off-platform coding agent and the in-app agent can continue from the same facts.

--- a/skills/langfuse/references/v4-project-migration.md
+++ b/skills/langfuse/references/v4-project-migration.md
@@ -8,13 +8,15 @@ metadata:
 
 # Langfuse v4 project migration
 
-Use this as the canonical project-side workflow. A coding agent should combine its output with the SDK upgrade workflow; the Langfuse in-app agent can execute the project steps and produce the same code handoff.
+Use this as the canonical v4 platform migration workflow. A coding agent should execute the SDK and code changes; the Langfuse in-app agent can execute the project steps and produce the same code handoff.
 
 ## Sources of truth
 
 Fetch the applicable pages before taking action:
 
 - [Langfuse v4 overview](https://langfuse.com/docs/v4)
+- [Langfuse CLI](https://langfuse.com/docs/api-and-data-platform/features/cli)
+- [SDK upgrade workflow](https://raw.githubusercontent.com/langfuse/skills/main/skills/langfuse/references/sdk-upgrade.md)
 - [Evaluator migration guide](https://langfuse.com/faq/all/llm-as-a-judge-migration)
 - [Observation evaluator context](https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge#observation-evaluator-context)
 - [Evaluators API](https://api.reference.langfuse.com/#tag/unstableevaluators)
@@ -26,7 +28,22 @@ Fetch the applicable pages before taking action:
 
 Discover the current API or tool schema before writes; the evaluator endpoints are unstable.
 
-## 1. Inventory active evaluation rules
+## 1. Set up project access
+
+- Prefer an available Langfuse project interface. Otherwise recommend the [Langfuse CLI](https://langfuse.com/docs/api-and-data-platform/features/cli) and run it directly with `npx langfuse-cli` or `bunx langfuse-cli`; a global installation is optional.
+- Ask the user to configure `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL` in their environment. Never ask them to paste secrets into the conversation or commit credentials.
+- Verify access and discover the current resources with `npx langfuse-cli api __schema`. Inspect each resource and action with `--help` before use, and request machine-readable output with `--json`.
+- Confirm the project and host before any read or write. If credentials or a project interface are unavailable, continue with the code migration and report project-side checks as blocked.
+
+## 2. Upgrade SDKs and instrumentation
+
+- For a coding agent with repository access, fetch and follow the [SDK upgrade workflow](https://raw.githubusercontent.com/langfuse/skills/main/skills/langfuse/references/sdk-upgrade.md) before declaring the platform migration ready.
+- Inventory every Langfuse SDK, integration package, direct OpenTelemetry exporter, initialization site, and lockfile across the repository. Upgrade each ingestion path to the latest stable release in the major required by the current v4 migration docs, unless the repository has a documented compatibility constraint.
+- Apply every applicable SDK migration step, update removed tracing APIs, and replace deprecated Observations, Scores, and Metrics API routes using the current docs. A dependency-only update is incomplete.
+- Use the evaluator migration contract below to consolidate all required evaluation input, output, metadata, tool calls, and propagated filter attributes onto the single target observation.
+- Verify the resolved versions and representative ingestion behavior. If the agent cannot access or edit the codebase, return an exact SDK and instrumentation handoff and keep this area blocked rather than marking it ready.
+
+## 3. Inventory active evaluation rules
 
 - Confirm the project, host, and whether it is Cloud or self-hosted.
 - Page through all available evaluators and evaluation rules. Inspect each referenced evaluator definition, not only its name.
@@ -34,7 +51,7 @@ Discover the current API or tool schema before writes; the evaluator endpoints a
 - Do not infer that the project has no legacy rules from the public list alone. Verify which targets the interface returns; if it omits legacy trace or dataset rules, use the UI check below.
 - Open the [Evaluators UI](https://cloud.langfuse.com/project/~/evals) and check for active rows marked **Legacy** whenever the interface cannot list those targets. In the in-app agent, redirect the user there. Treat this confirmation as required before declaring the project ready.
 
-## 2. Build an evaluator migration contract
+## 4. Build an evaluator migration contract
 
 For every active legacy rule, record:
 
@@ -53,7 +70,7 @@ For every active legacy rule, record:
 - Observation evaluators see only the matched observation. If the evaluator needs an end-to-end request, response, or summary assembled from multiple steps, target a root observation and require the application to write that context onto it.
 - Rebuild filters and mappings deliberately. Do not assume the UI upgrade wizard semantically preserves a legacy rule.
 
-## 3. Create and cut over successor rules
+## 5. Create and cut over successor rules
 
 - Reuse the existing evaluator definition when it remains valid. Create a new evaluator version only when the prompt, output definition, or variable contract must change.
 - Update an existing successor rule instead of creating a duplicate with the same name.
@@ -65,7 +82,7 @@ For every active legacy rule, record:
 
 If the available project interface cannot read or update a legacy rule, provide the exact [Evaluators UI](https://cloud.langfuse.com/project/~/evals) action and retain it as an explicit blocker rather than claiming completion.
 
-## 4. Migrate exports
+## 6. Migrate exports
 
 - Inventory configured Blob Storage, Mixpanel, PostHog, and other export integrations in **Project Settings > Integrations**.
 - For Blob Storage, inspect or update the integration through the API when organization-scoped credentials and the current schema are available. Otherwise direct the user to [Blob Storage settings](https://cloud.langfuse.com/project/~/settings/integrations/blobstorage).
@@ -74,11 +91,12 @@ If the available project interface cannot read or update a legacy rule, provide 
 - Do not overwrite bucket credentials, schedules, prefixes, file formats, field groups, or integration secrets while changing the export source.
 - Treat the downstream consumer update as part of the migration. A source toggle without validating queries, joins, dashboards, and field parsing is incomplete.
 
-## 5. Report readiness
+## 7. Report readiness
 
 Return one row per area with `ready`, `changed`, `manual action`, or `blocked`:
 
-- SDK and instrumentation code handoff
+- CLI or project-interface setup
+- SDK versions and instrumentation migration, including any code handoff
 - active trace-to-observation evaluator migrations
 - active dataset-to-experiment evaluator migrations
 - deprecated API code handoff


### PR DESCRIPTION
Linear: [LFE-10897](https://linear.app/langfuse/issue/LFE-10897/create-skill-for-v3-v4-migration)

## Summary

- add a standalone Langfuse v4 platform migration workflow for SDK, evaluator, API, and export migrations
- recommend setting up the Langfuse CLI when no native project interface is available
- make upgrading every SDK and ingestion path to the latest compatible stable release an explicit prerequisite
- keep the workflow reusable by the in-app agent through the existing `LANGFUSE_PROJECT_INTERFACE` skill sync
- add a lean copyable prompt that points coding agents at the canonical workflow files
- bump the Claude, Cursor, and Codex plugin manifests from `1.2.x` to `1.3.0`

## Why

The v4 platform migration spans two execution environments: application code and project configuration. Keeping one large prompt for off-platform agents and another for the in-app agent would duplicate fast-changing SDK, evaluator, and export instructions.

This change splits detailed execution by required access while making the standalone v4 workflow complete: it establishes project access, requires the SDK/instrumentation upgrade, and then drives evaluator and export migration. Coding agents can execute both code and project steps; the in-app agent can execute project steps and produce the same exact code handoff.

The workflow also guards against a false readiness result: the public evaluation-rule interface may omit legacy trace and dataset rules, so agents must confirm active **Legacy** rows in the Evaluators UI before declaring the project migrated.

## User impact

The new copy prompt instructs a coding agent to fetch the canonical workflows, implement and validate applicable code/project changes, and report UI-only or blocked steps. The workflows cover:

- Langfuse CLI setup and safe credential handling
- current SDK and instrumentation migration from the live docs
- active trace-to-observation and dataset-to-experiment evaluator cutovers
- self-contained observation context for evaluator variables and filters
- deprecated Observations, Scores, and Metrics API usage
- staged Blob Storage, Mixpanel, and PostHog export migration to enriched observations
- explicit verification, rollback, and manual-action reporting

After merge, the existing in-app-agent sync can pull `v4-project-migration.md` because its only required access is `LANGFUSE_PROJECT_INTERFACE`.

## Validation

- `git diff --check`
- JSON parsing and `1.3.0` version alignment for all three plugin manifests
- YAML/frontmatter parsing for every Langfuse reference
- verified the current CLI, v4 overview, and SDK upgrade documentation
- verified the v4 project reference remains eligible for the existing in-app-agent sync
- previous disposable forward test against a legacy Python fixture: upgraded the SDK and instrumentation, consolidated evaluator context onto a root observation, replaced a legacy Metrics path, and correctly deferred project mutations when credentials were absent
