### PR TITLE
docs(langfuse): add trace self-audit step to instrumentation guide

### DIFF
--- a/skills/langfuse/references/instrumentation.md
+++ b/skills/langfuse/references/instrumentation.md
@@ -43,72 +43,46 @@ Framework integrations (OpenAI, LangChain, etc.) handle model name, tokens, and 
 
 Docs: https://langfuse.com/docs/tracing
 
-### 3. Explore Traces First
+**Beyond the baseline**, add context relevant to the app. Infer from code where possible; only ask when it's not obvious (e.g. how they judge a good vs. bad response, what they'd filter a dashboard by, which user segments they'd compare). These are not baseline — add only what fits.
 
-Once baseline instrumentation is working, encourage the user to explore their traces in the Langfuse UI before adding more context:
+| If code shows...                                     | Add                 | Why                                                                             |
+| ---------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------- |
+| Conversation history, chat endpoints, message arrays | `session_id`        | Groups conversations — [docs](https://langfuse.com/docs/tracing-features/sessions) |
+| User authentication, `user_id` variables             | `user_id`           | User filtering and cost attribution — [docs](https://langfuse.com/docs/tracing-features/users) |
+| Multiple distinct endpoints/features                 | `feature` tag       | Per-feature analytics — [docs](https://langfuse.com/docs/tracing-features/tags) |
+| Customer/tenant identifiers                          | `customer_tier` tag | Cost/quality breakdown by segment — [docs](https://langfuse.com/docs/tracing-features/tags) |
+| Feedback collection, ratings                         | Feedback score      | Quality filtering and trends — [docs](https://langfuse.com/docs/scores/overview) |
 
-"Your traces are now appearing in Langfuse. Take a look at a few of them—see what data is being captured, what's useful, and what's missing. This will help us decide what additional context to add."
+### 3. Run and Self-Audit the Traces (required)
 
-This helps the user:
+Instrumentation isn't done when the code compiles. This is a loop you own as the agent, it's your responsibility to deliver traces of the highest quality your can produce:
 
-- Understand what they're already getting
-- Form opinions about what's missing
-- Ask better questions about what they need
+**a.** Execute the instrumented path end-to-end so a trace is actually sent.
 
-### 4. Discover Additional Context Needs
+**b.** Fetch the trace(s) you just created from Langfuse. Any method works (`langfuse-cli`, REST API, SDK, MCP); the CLI is usually simplest — see [references/cli.md](references/cli.md).
 
-Determine what additional instrumentation would be valuable. **Infer from code when possible, only ask when unclear.**
+**c.** Audit the trace against the best-practices page. **Always fetch it fresh — never audit from memory, this cannot be skipped** (the guidance changes over time):
 
-**Infer from code:**
+https://langfuse.com/docs/observability/best-practices
 
-| If you see in code...                                | Infer             | Suggest                   |
-| ---------------------------------------------------- | ----------------- | ------------------------- |
-| Conversation history, chat endpoints, message arrays | Multi-turn app    | `session_id`              |
-| User authentication, `user_id` variables             | User-aware app    | `user_id` on traces       |
-| Multiple distinct endpoints/features                 | Multi-feature app | `feature` tag             |
-| Customer/tenant identifiers                          | Multi-tenant app  | `customer_id` or tier tag |
-| Feedback collection, ratings                         | Has user feedback | Capture as scores         |
+Ask yourself, for each observation: is all data that a user might need in the future, to understand exactly what context the agent had when it made decisions, available in Langfuse?
 
-**Only ask when not obvious from code:**
+**d.** Fix every gap you find, then re-run and re-fetch to confirm. Repeat until the trace clears the guidance. Then report what you audited and changed, and link the final trace.
 
-- "How do you know when a response is good vs bad?" → Determines scoring approach
-- "What would you want to filter by in a dashboard?" → Surfaces non-obvious tags
-- "Are there different user segments you'd want to compare?" → Customer tiers, plans, etc.
+### 4. Explore Traces With the User
 
-**Additions and their value:**
+With a clean trace in place, invite the user to explore it in the Langfuse UI:
 
-| Addition            | Why                                         | Docs                                                |
-| ------------------- | ------------------------------------------- | --------------------------------------------------- |
-| `session_id`        | Groups conversations together               | https://langfuse.com/docs/tracing-features/sessions |
-| `user_id`           | Enables user filtering and cost attribution | https://langfuse.com/docs/tracing-features/users    |
-| User feedback score | Enables quality filtering and trends        | https://langfuse.com/docs/scores/overview           |
-| `feature` tag       | Per-feature analytics                       | https://langfuse.com/docs/tracing-features/tags     |
-| `customer_tier` tag | Cost/quality breakdown by segment           | https://langfuse.com/docs/tracing-features/tags     |
+"Your traces are now appearing in Langfuse. Take a look at a few of them—see what data is being captured, what's useful, and what's missing."
 
-These are NOT baseline requirements—only add what's relevant based on inference or user input.
+Point them to the relevant views:
 
-### 5. Guide to UI
+- Traces view: individual requests
+- Sessions view: grouped conversations (if `session_id` added)
+- Dashboard: filtered views using tags
+- Scores: filter by quality metrics
 
-After adding context, point users to relevant UI features:
-
-- Traces view: See individual requests
-- Sessions view: See grouped conversations (if session_id added)
-- Dashboard: Build filtered views using tags
-- Scores: Filter by quality metrics
-
-## Framework Integrations
-
-Prefer these over manual instrumentation:
-
-| Framework     | Integration            | Docs                                                 |
-| ------------- | ---------------------- | ---------------------------------------------------- |
-| OpenAI SDK    | Drop-in replacement    | https://langfuse.com/docs/integrations/openai        |
-| LangChain     | Callback handler       | https://langfuse.com/docs/integrations/langchain     |
-| LlamaIndex    | Callback handler       | https://langfuse.com/docs/integrations/llama-index   |
-| Vercel AI SDK | OpenTelemetry exporter | https://langfuse.com/docs/integrations/vercel-ai-sdk |
-| LiteLLM       | Callback or proxy      | https://langfuse.com/docs/integrations/litellm       |
-
-Full list: https://langfuse.com/docs/integrations
+This helps them understand what they're getting, spot what's missing, and ask better questions about what to add next.
 
 ## Always Explain Why
 


### PR DESCRIPTION
Adds a required self-audit loop to the instrumentation reference: after writing instrumentation, agents must run the app, fetch their own traces from Langfuse, and audit them against the best-practices page (always fetched fresh, never from memory) until the trace is good. Consolidates the workflow to four steps by folding additional-context guidance into the baseline step and merging the UI guide into the trace-exploration step, and drops the standalone Framework Integrations section.