### PR TITLE
fix(langfuse): make export-source consequences explicit in v4 migration

### DIFF
--- a/skills/langfuse/references/v4-project-migration.md
+++ b/skills/langfuse/references/v4-project-migration.md
@@ -84,12 +84,18 @@ If the available project interface cannot read or update a legacy rule, provide 
 
 ## 6. Migrate exports
 
+Changing the export source is a breaking change for every downstream consumer, not a settings toggle. Before proposing or making any source change, explain the concrete consequences for each configured integration and obtain the user's explicit confirmation that downstream owners are prepared.
+
 - Inventory configured Blob Storage, Mixpanel, PostHog, and other export integrations in **Project Settings > Integrations**.
+- Spell out what the source change does per integration before touching it:
+  - **Blob Storage:** the exported tables and file paths change. Legacy writes `traces` and `observations` files; enriched writes `observations_v2` under a new directory prefix, and the separate `traces` file is no longer produced in enriched-only mode. Column sets differ per the [export field reference](https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-vs-legacy-differences), so loaders, warehouse table schemas, trace-observation joins, and dashboards across the full data pipeline must be updated — not just the integration setting.
+  - **Mixpanel and PostHog:** the source determines which events and properties are sent, so dashboards, transformations, funnels, and alerts built on the legacy events in those systems are affected and must be revalidated.
+  - **Dual mode** (`legacy and enriched observations`) creates duplicate records by design. Warn that counts, costs, and metrics in downstream systems will be inflated until consumers deduplicate or the transition completes.
 - For Blob Storage, inspect or update the integration through the API when organization-scoped credentials and the current schema are available. Otherwise direct the user to [Blob Storage settings](https://cloud.langfuse.com/project/~/settings/integrations/blobstorage).
 - For Mixpanel and PostHog, use the UI and the linked migration guides. Do not claim an API migration path that the current interface does not provide.
-- Prefer the documented dual-export transition: enable legacy plus enriched observations, update and validate downstream consumers against the field reference, then switch to enriched observations only.
+- Follow the documented dual-export transition: enable legacy plus enriched observations, update and validate downstream consumers against the field reference, then switch to enriched observations only. Never switch a legacy integration directly to enriched-only while downstream consumers are unvalidated.
 - Do not overwrite bucket credentials, schedules, prefixes, file formats, field groups, or integration secrets while changing the export source.
-- Treat the downstream consumer update as part of the migration. A source toggle without validating queries, joins, dashboards, and field parsing is incomplete.
+- Treat the downstream consumer update as part of the migration. A source toggle without validating queries, joins, dashboards, and field parsing is incomplete; report this area as `manual action`, not `ready`, until the user confirms consumers handle the new schema.
 
 ## 7. Report readiness
 


### PR DESCRIPTION
## Problem

The "Migrate exports" section of the v4 project migration workflow was too soft. Changing the export source is a breaking change: it changes the exported schema and produces differently named files (`traces` + `observations` vs `observations_v2`, with the separate `traces` file disappearing in enriched-only mode). This impacts the respective downstream systems for PostHog and Mixpanel, and the full data pipeline for Blob Storage exports — but the section treated it like a settings toggle.

## Change

Revised section 6 ("Migrate exports") so the agent must make the user understand the consequences before any change:

- New framing: changing the export source is a breaking change for every downstream consumer; the agent must explain the concrete consequences per integration and obtain explicit user confirmation before proposing or making any source change.
- Per-integration consequence bullets the agent must spell out first:
  - **Blob Storage** — exported tables and file paths change; column sets differ per the [field reference](https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-vs-legacy-differences); loaders, warehouse schemas, trace-observation joins, and dashboards across the full pipeline must be updated.
  - **Mixpanel / PostHog** — the source determines which events and properties are sent; dashboards, transformations, funnels, and alerts in those systems must be revalidated.
  - **Dual mode** — duplicates records by design; counts, costs, and metrics downstream are inflated until consumers deduplicate or the transition completes.
- "Prefer the documented dual-export transition" tightened to "Follow", with an explicit prohibition on switching a legacy integration straight to enriched-only while consumers are unvalidated.
- The export area must be reported as `manual action`, not `ready`, until the user confirms consumers handle the new schema.

All consequence claims were verified against the current Langfuse docs (blob storage export page, PostHog and Mixpanel integration pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)