### PR TITLE
ci: add Claude review bot and PR review guidance

### DIFF
--- a/.github/workflows/claude-review-maintainer-prs.yml
+++ b/.github/workflows/claude-review-maintainer-prs.yml
@@ -1,0 +1,69 @@
+name: Claude Review on Maintainer PRs
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+
+jobs:
+  comment:
+    # Only run on PRs that are not drafts and are from the same repository (i.e., not from forks).
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Check author permission and existing review request
+        id: check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.pull_request.number;
+            const username = context.payload.pull_request.user.login;
+
+            let permission = "none";
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username,
+              });
+              permission = data.permission;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            const canWrite = ["write", "admin"].includes(permission);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const hasReviewRequest = comments.some(
+              (comment) => comment.body?.trim() === "@claude review",
+            );
+
+            core.info(
+              `PR #${issue_number} by ${username}: permission=${permission}, hasReviewRequest=${hasReviewRequest}`,
+            );
+
+            core.setOutput("should_comment", canWrite && !hasReviewRequest ? "true" : "false");
+
+      - name: Add Claude review comment
+        if: steps.check.outputs.should_comment == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: "@claude review",
+            });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,20 @@ When to bump (follow semver):
 
 When **not** to bump:
 - Typo fixes, formatting, comment-only changes.
-- Changes to repo tooling, CI, or files outside the published skills (e.g. this `agents.md`, READMEs, GitHub workflows).
+- Changes to repo tooling, CI, or files outside the published skills (e.g. this `AGENTS.md`, READMEs, GitHub workflows).
 - Internal refactors that don't change observable skill behavior.
 
 If unsure whether a change warrants a bump, err on the side of bumping patch.
+
+## Reviewing Pull Requests
+
+When reviewing a PR (e.g. triggered by `@claude review`), enforce the principles above — they are the review criteria, not just authoring advice. Do not restate them in the review; call out where the diff violates them. Focus on:
+
+- **Does the addition beat the docs?** Flag any new use case or reference content an agent could already get by fetching the Langfuse docs. Every addition is maintenance surface.
+- **No committed code.** Flag committed code samples that should instead link to a Langfuse docs page; pseudo-code for logic-specific bits is fine.
+- **`metadata.required_access` present and correct.** Every reference file's frontmatter must declare it, using only the allowed tokens.
+- **Routing lives in exactly two places.** A one-line entry in `## Use case specific references` in `SKILL.md` and the reference file's frontmatter `description` — nowhere else.
+- **Version bumps in lockstep.** If published skill behavior changed, both `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` must be bumped to the same version in the PR (and no bump for tooling/docs-only changes).
+- **CLI path sync.** If a skill's path changed, the [CLI repo](https://github.com/langfuse/langfuse-cli) reference must be updated too.
+
+Prioritize correctness and adherence to these principles over style nits. If the diff is clean against all of the above, say so plainly.


### PR DESCRIPTION
Sets up the Claude review bot in this repo, mirroring the pattern used in [langfuse-docs](https://github.com/langfuse/langfuse-docs).

## Changes

- **Add `.github/workflows/claude-review-maintainer-prs.yml`** — auto-posts `@claude review` on non-draft, non-fork PRs opened by maintainers (write/admin), deduping so it only comments once. Action pinned to a commit SHA.
- **Rename `agents.md` → `AGENTS.md`** — so the Claude GitHub App and Claude Code reliably load the repo guidance on case-sensitive CI.
- **Add a `## Reviewing Pull Requests` section to `AGENTS.md`** — maps the existing authoring principles to review criteria (beats-the-docs test, no committed code, `required_access` present, routing-in-two-places, plugin version lockstep, CLI path sync) so the reviewer enforces them rather than restating them.

## Follow-up (not in this PR)

The **Claude GitHub App must be installed on `langfuse/skills`** for the posted `@claude review` comment to get a response. This is an org-owner action (`/install-github-app` or github.com/apps/claude).