### PR TITLE
feat: route skill feedback through Langfuse intake

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -8,10 +8,12 @@ allowed-tools:
   - Bash(npx langfuse-cli api * --help *)
   - Bash(npx langfuse-cli api * list *)
   - Bash(npx langfuse-cli api * get *)
+  - Bash(npx langfuse-cli api feedback *)
   - Bash(bunx langfuse-cli api __schema *)
   - Bash(bunx langfuse-cli api * --help *)
   - Bash(bunx langfuse-cli api * list *)
   - Bash(bunx langfuse-cli api * get *)
+  - Bash(bunx langfuse-cli api feedback *)
 ---
 
 # Langfuse
@@ -130,16 +132,3 @@ Search is a great fallback if you cannot find the relevant pages or need more co
 1. Start with **llms.txt** to orient — scan for relevant page titles
 2. **Fetch specific pages** when you identify the right one
 3. Fall back to **search** when the topic is unclear and you want more context
-
-## Skill Feedback
-
-When the user expresses that something about this skill is not working as expected, gives incorrect guidance, is missing information, or could be improved — offer to submit feedback to the Langfuse skill maintainers. This includes when:
-
-- The skill gave wrong or outdated instructions
-- A workflow didn't produce the expected result
-- The user wishes the skill covered something it doesn't
-- The user explicitly says something like "this should work differently" or "this is wrong"
-
-**Do NOT trigger this** for issues with Langfuse itself (the product) — only for issues with this skill's instructions and behavior.
-
-When triggered, follow the process in [references/skill-feedback.md](references/skill-feedback.md).

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -41,7 +41,7 @@ Follow these principles for ALL Langfuse work:
 - judge calibration (LLM-as-a-Judge reliability, simple accuracy checks, advanced split-based validation, confusion matrices, and metric ingestion): references/judge-calibration.md
 - systematic error analysis — reading traces, building failure taxonomy, deciding what to fix: references/error-analysis.md
 - setting up CI/CD experiment gates with `langfuse/experiment-action`: references/ci-cd.md
-- submitting feedback about this skill — offer once when this skill gave wrong or outdated guidance (never for issues with Langfuse itself): references/skill-feedback.md
+- submitting feedback about this skill: references/skill-feedback.md
 
 
 ## 1. Langfuse API via CLI
@@ -132,3 +132,15 @@ Search is a great fallback if you cannot find the relevant pages or need more co
 2. **Fetch specific pages** when you identify the right one
 3. Fall back to **search** when the topic is unclear and you want more context
 
+## Skill Feedback
+
+When the user expresses that something about this skill is not working as expected, gives incorrect guidance, is missing information, or could be improved — offer to submit feedback to the Langfuse skill maintainers. This includes when:
+
+- The skill gave wrong or outdated instructions
+- A workflow didn't produce the expected result
+- The user wishes the skill covered something it doesn't
+- The user explicitly says something like "this should work differently" or "this is wrong"
+
+**Do NOT trigger this** for issues with Langfuse itself (the product) — only for issues with this skill's instructions and behavior.
+
+When triggered, follow the process in [references/skill-feedback.md](references/skill-feedback.md).

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -8,12 +8,10 @@ allowed-tools:
   - Bash(npx langfuse-cli api * --help *)
   - Bash(npx langfuse-cli api * list *)
   - Bash(npx langfuse-cli api * get *)
-  - Bash(npx langfuse-cli api feedback *)
   - Bash(bunx langfuse-cli api __schema *)
   - Bash(bunx langfuse-cli api * --help *)
   - Bash(bunx langfuse-cli api * list *)
   - Bash(bunx langfuse-cli api * get *)
-  - Bash(bunx langfuse-cli api feedback *)
 ---
 
 # Langfuse
@@ -42,7 +40,7 @@ Follow these principles for ALL Langfuse work:
 - judge calibration (LLM-as-a-Judge reliability, simple accuracy checks, advanced split-based validation, confusion matrices, and metric ingestion): references/judge-calibration.md
 - systematic error analysis — reading traces, building failure taxonomy, deciding what to fix: references/error-analysis.md
 - setting up CI/CD experiment gates with `langfuse/experiment-action`: references/ci-cd.md
-- submitting feedback about this skill: references/skill-feedback.md
+- submitting feedback about this skill — offer once when this skill gave wrong or outdated guidance (never for issues with Langfuse itself): references/skill-feedback.md
 
 
 ## 1. Langfuse API via CLI

--- a/skills/langfuse/references/skill-feedback.md
+++ b/skills/langfuse/references/skill-feedback.md
@@ -1,55 +1,19 @@
 ---
 name: langfuse-skill-feedback
-description: Submit feedback about the Langfuse skill to its maintainers via GitHub Discussions. Use when the user indicates the skill gave incorrect guidance, is missing information, or could be improved.
+description: Submit approved feedback about the Langfuse skill through authenticated Langfuse feedback intake, with a GitHub issue as the unauthenticated fallback.
 metadata:
   required_access:
+    - LANGFUSE_PROJECT_INTERFACE
     - GITHUB
 ---
 
 # Skill Feedback
 
-Follow these steps exactly:
+This workflow is only for feedback about the Langfuse skill's instructions and behavior, not product support or a user's application data.
 
-1. **Ask permission**: Ask the user if they'd like you to submit feedback to the skill maintainers. Make it clear this is about the skill (the agent instructions), not about Langfuse the product. If they decline, move on.
-2. **Draft feedback**: Write the feedback using the form structure below. Present the draft to the user and ask if they'd like to change anything before submitting.
-3. **Submit**: Once approved, submit via `gh` CLI as described below. Share the resulting discussion URL with the user.
-
-## Feedback Form Structure
-
-Draft the feedback using these two fields:
-
-**Describe your idea or feedback** (required)
-A clear description of what went wrong or what could be improved. Include:
-- What the user was trying to do
-- What the skill did vs what was expected
-- Any specific instructions that were incorrect or missing
-
-**What would the ideal outcome look like?** (optional)
-What the correct behavior or guidance should be.
-
-Format the body as markdown with the two field labels as headings.
-
-## Submitting
-
-Create a GitHub Discussion on the `langfuse/skills` repository using the GraphQL API:
-
-```bash
-gh api graphql -f query='
-mutation($repoId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
-  createDiscussion(input: {repositoryId: $repoId, categoryId: $categoryId, title: $title, body: $body}) {
-    discussion { url }
-  }
-}' \
-  -f repoId="$(gh api graphql -f query='{ repository(owner: "langfuse", name: "skills") { id } }' --jq '.data.repository.id')" \
-  -f categoryId="$(gh api graphql -f query='{ repository(owner: "langfuse", name: "skills") { discussionCategories(first: 10) { nodes { id name } } } }' --jq '.data.repository.discussionCategories.nodes[] | select(.name == "Ideas & Improvements") | .id')" \
-  -f title="<concise title>" \
-  -f body="<formatted feedback>"
-```
-
-If the `gh` CLI is not authenticated or the request fails, give the user this link to create the discussion manually:
-
-```
-https://github.com/langfuse/skills/discussions/new?category=ideas-improvements
-```
-
-After submission, share the discussion URL with the user.
+1. Draft concise feedback that explains what the user was trying to do, what the skill did, and what should improve. Use `targetType` `skill` and target `langfuse`. Add a goal or reference URL only when the user supplied it and it is necessary.
+2. Remove secrets, credentials, customer data, trace payloads, and unrelated conversation context. Never infer or attach those details.
+3. Show the user every user-controlled field exactly as it will be submitted and ask for explicit permission. Do not submit if they decline or have not approved the final draft.
+4. Prefer the authenticated in-app `submitFeedback` MCP tool when it is available. Otherwise discover the current public API operation with the Langfuse CLI schema and operation help, then submit through the authenticated project interface. Do not add client-identification headers.
+5. If authenticated feedback intake is unavailable, unconfigured, or unsupported, offer to create an issue in [`langfuse/skills`](https://github.com/langfuse/skills/issues/new). Treat this as a separate external write and obtain approval before creating it.
+6. Report the receipt ID returned by Langfuse or the GitHub issue URL. If submission fails, state the safe error without exposing request bodies or credentials.

--- a/skills/langfuse/references/skill-feedback.md
+++ b/skills/langfuse/references/skill-feedback.md
@@ -20,7 +20,7 @@ Use this only for feedback about the skill itself, not Langfuse the product or a
   - **What would the ideal outcome look like?** (optional)
     What the correct behavior or guidance should be.
 
-  Add `referenceUrl` only when supplied by the user and useful.
+  If feedback targets existing skill, reference in `target`.
 2. If the user wants a reply, ask them to include an email address in `feedback`; use only an address they explicitly provide.
 3. Show every submitted field exactly as it will be sent and ask for explicit permission. Do not submit without approval.
 

--- a/skills/langfuse/references/skill-feedback.md
+++ b/skills/langfuse/references/skill-feedback.md
@@ -10,8 +10,8 @@ metadata:
 
 This workflow is only for feedback about the Langfuse skill's instructions and behavior, not product support or a user's application data.
 
-1. Draft concise feedback that explains what the user was trying to do, what the skill did, and what should improve. Use `targetType` `skill` and target `langfuse`. Add a goal or reference URL only when the user supplied it and it is necessary.
-2. Remove secrets, credentials, customer data, trace payloads, and unrelated conversation context. Never infer or attach those details.
+1. Draft concise feedback that explains what the user was trying to do, what the skill did, and what should improve. Use `targetType` `skill` and target `langfuse`. Add a goal or reference URL only when the user supplied it and it is necessary. If the user wants a reply, ask them to include their email address in the feedback text; use only an address they explicitly provide.
+2. Remove secrets, credentials, customer data, trace payloads, and unrelated conversation context. Do not infer or attach contact details; preserve only an email address the user explicitly provided for a requested reply.
 3. Show the user every user-controlled field exactly as it will be submitted and ask for explicit permission. In the same question, offer a public GitHub discussion as the alternative for users who want a thread they can track. Do not submit if they decline or have not approved the final draft.
 4. Default to authenticated intake: prefer the `submitFeedback` tool on the Langfuse MCP server when it is available. Otherwise discover the current public API operation with the Langfuse CLI schema and operation help, then submit through the authenticated project interface. Do not add client-identification headers.
 5. If the user chooses GitHub, or authenticated intake is unavailable, unconfigured, or unsupported, build a prefilled link to a new discussion from the approved draft and share it for the user to submit themselves: `https://github.com/langfuse/skills/discussions/new?category=ideas-improvements&title=<url-encoded title>&body=<url-encoded body>`.

--- a/skills/langfuse/references/skill-feedback.md
+++ b/skills/langfuse/references/skill-feedback.md
@@ -1,10 +1,9 @@
 ---
 name: langfuse-skill-feedback
-description: Submit approved feedback about the Langfuse skill through authenticated Langfuse feedback intake, with a GitHub issue as the unauthenticated fallback.
+description: Submit approved feedback about the Langfuse skill through authenticated Langfuse feedback intake, or via a prefilled GitHub discussion link when the user prefers a public thread or intake is unavailable. Offer once when this skill gave incorrect or outdated guidance — never for issues with Langfuse itself.
 metadata:
   required_access:
     - LANGFUSE_PROJECT_INTERFACE
-    - GITHUB
 ---
 
 # Skill Feedback
@@ -13,7 +12,7 @@ This workflow is only for feedback about the Langfuse skill's instructions and b
 
 1. Draft concise feedback that explains what the user was trying to do, what the skill did, and what should improve. Use `targetType` `skill` and target `langfuse`. Add a goal or reference URL only when the user supplied it and it is necessary.
 2. Remove secrets, credentials, customer data, trace payloads, and unrelated conversation context. Never infer or attach those details.
-3. Show the user every user-controlled field exactly as it will be submitted and ask for explicit permission. Do not submit if they decline or have not approved the final draft.
-4. Prefer the authenticated in-app `submitFeedback` MCP tool when it is available. Otherwise discover the current public API operation with the Langfuse CLI schema and operation help, then submit through the authenticated project interface. Do not add client-identification headers.
-5. If authenticated feedback intake is unavailable, unconfigured, or unsupported, offer to create an issue in [`langfuse/skills`](https://github.com/langfuse/skills/issues/new). Treat this as a separate external write and obtain approval before creating it.
-6. Report the receipt ID returned by Langfuse or the GitHub issue URL. If submission fails, state the safe error without exposing request bodies or credentials.
+3. Show the user every user-controlled field exactly as it will be submitted and ask for explicit permission. In the same question, offer a public GitHub discussion as the alternative for users who want a thread they can track. Do not submit if they decline or have not approved the final draft.
+4. Default to authenticated intake: prefer the `submitFeedback` tool on the Langfuse MCP server when it is available. Otherwise discover the current public API operation with the Langfuse CLI schema and operation help, then submit through the authenticated project interface. Do not add client-identification headers.
+5. If the user chooses GitHub, or authenticated intake is unavailable, unconfigured, or unsupported, build a prefilled link to a new discussion from the approved draft and share it for the user to submit themselves: `https://github.com/langfuse/skills/discussions/new?category=ideas-improvements&title=<url-encoded title>&body=<url-encoded body>`.
+6. Report the correlation ID returned by Langfuse or the discussion URL. If submission fails, state the safe error without exposing request bodies or credentials.

--- a/skills/langfuse/references/skill-feedback.md
+++ b/skills/langfuse/references/skill-feedback.md
@@ -1,6 +1,6 @@
 ---
 name: langfuse-skill-feedback
-description: Submit approved feedback about the Langfuse skill through authenticated Langfuse feedback intake, or via a prefilled GitHub discussion link when the user prefers a public thread or intake is unavailable. Offer once when this skill gave incorrect or outdated guidance — never for issues with Langfuse itself.
+description: Submit feedback about the Langfuse skill to its maintainers. Use when the skill's instructions are wrong, outdated, missing something, or could be improved.
 metadata:
   required_access:
     - LANGFUSE_PROJECT_INTERFACE
@@ -8,11 +8,18 @@ metadata:
 
 # Skill Feedback
 
-This workflow is only for feedback about the Langfuse skill's instructions and behavior, not product support or a user's application data.
+Use this only for feedback about the skill itself, not Langfuse the product or a user's application data.
 
-1. Draft concise feedback that explains what the user was trying to do, what the skill did, and what should improve. Use `targetType` `skill` and target `langfuse`. Add a goal or reference URL only when the user supplied it and it is necessary. If the user wants a reply, ask them to include their email address in the feedback text; use only an address they explicitly provide.
-2. Remove secrets, credentials, customer data, trace payloads, and unrelated conversation context. Do not infer or attach contact details; preserve only an email address the user explicitly provided for a requested reply.
-3. Show the user every user-controlled field exactly as it will be submitted and ask for explicit permission. In the same question, offer a public GitHub discussion as the alternative for users who want a thread they can track. Do not submit if they decline or have not approved the final draft.
-4. Default to authenticated intake: prefer the `submitFeedback` tool on the Langfuse MCP server when it is available. Otherwise discover the current public API operation with the Langfuse CLI schema and operation help, then submit through the authenticated project interface. Do not add client-identification headers.
-5. If the user chooses GitHub, or authenticated intake is unavailable, unconfigured, or unsupported, build a prefilled link to a new discussion from the approved draft and share it for the user to submit themselves: `https://github.com/langfuse/skills/discussions/new?category=ideas-improvements&title=<url-encoded title>&body=<url-encoded body>`.
-6. Report the correlation ID returned by Langfuse or the discussion URL. If submission fails, state the safe error without exposing request bodies or credentials.
+1. Draft concise feedback about what the user tried, what happened, and what should improve. Use `targetType: skill` and `target: langfuse`. Add `goal` or `referenceUrl` only when supplied by the user and useful.
+2. Remove secrets, credentials, customer data, trace payloads, and unrelated context. If the user wants a reply, ask them to include an email address in `feedback`; use only an address they explicitly provide.
+3. Show every submitted field exactly as it will be sent and ask for explicit permission. Do not submit without approval.
+
+## Submission options
+
+Use the first available option, or the option the user prefers:
+
+1. **Authenticated Langfuse MCP, CLI, or Public API** — prefer the `submitFeedback` tool on the Langfuse MCP server. If it is unavailable, discover the current feedback operation with the Langfuse CLI schema/help and submit through the authenticated Public API. Do not ask users to paste credentials into chat.
+2. **Langfuse Docs MCP** — use its unauthenticated `submitFeedback` tool when no authenticated Langfuse interface is available.
+3. **GitHub issue or discussion** — if no MCP/CLI/API is available, or the user wants a public, trackable thread, provide a prefilled discussion link for the user to submit: `https://github.com/langfuse/skills/discussions/new?category=ideas-improvements&title=<url-encoded title>&body=<url-encoded body>`. Use `https://github.com/langfuse/skills/issues/new` if they prefer an issue.
+
+Report the Langfuse correlation ID or GitHub URL. If submission fails, give a safe error without exposing credentials or request bodies.

--- a/skills/langfuse/references/skill-feedback.md
+++ b/skills/langfuse/references/skill-feedback.md
@@ -10,8 +10,18 @@ metadata:
 
 Use this only for feedback about the skill itself, not Langfuse the product or a user's application data.
 
-1. Draft concise feedback about what the user tried, what happened, and what should improve. Use `targetType: skill` and `target: langfuse`. Add `goal` or `referenceUrl` only when supplied by the user and useful.
-2. Remove secrets, credentials, customer data, trace payloads, and unrelated context. If the user wants a reply, ask them to include an email address in `feedback`; use only an address they explicitly provide.
+1. Draft concise feedback using the following structure:
+  - **Describe your idea or feedback** (required)
+    A clear description of what went wrong or what could be improved. Include:
+    - What the user was trying to do (as `goal`)
+    - What the skill did vs what was expected
+    - Any specific instructions that were incorrect or missing
+
+  - **What would the ideal outcome look like?** (optional)
+    What the correct behavior or guidance should be.
+
+  Add `referenceUrl` only when supplied by the user and useful.
+2. If the user wants a reply, ask them to include an email address in `feedback`; use only an address they explicitly provide.
 3. Show every submitted field exactly as it will be sent and ask for explicit permission. Do not submit without approval.
 
 ## Submission options


### PR DESCRIPTION
## Summary

- prefer the authenticated `submitFeedback` tool on the Langfuse MCP server, then the generated public API through langfuse-cli
- require an exact payload preview and explicit permission; the consent step also offers a public GitHub discussion for users who want a trackable thread
- fall back to a prefilled GitHub discussion link (Ideas & Improvements) when intake is unavailable or unconfigured — user submits it themselves, no `gh` auth needed
- keep the CLI allowlist read-only: the feedback submit call intentionally goes through the normal permission prompt
- proactive trigger (offer once on wrong/outdated guidance) lives in the references-list entry and the reference frontmatter, per AGENTS.md routing rules
- bump all plugin manifests to 1.5.0 (minor: new capability per semver policy)

## Verification

- plugin manifests parse and versions are aligned
- git diff --check passes

Tests added: 0 — instruction-only behavior with no test harness in this repository.
