### PR TITLE
docs: clarify prerequisites wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ln -s /path/to/langfuse-skills/skills/langfuse /path/to/skills-directory/langfus
 
 ## Prerequisites
 
-You need a Langfuse account ([cloud](https://cloud.langfuse.com) or [self-hosted](https://langfuse.com/docs/deployment/self-host)) and API keys:
+You need a Langfuse account ([cloud](https://cloud.langfuse.com) or [self-hosted](https://langfuse.com/docs/deployment/self-host)) and API keys to get started:
 
 ```bash
 export LANGFUSE_PUBLIC_KEY=pk-lf-...


### PR DESCRIPTION
Test PR to exercise the Claude review bot integration. Makes a small wording tweak to the README prerequisites section.