### PR TITLE
Rework v4-migration export section: defer to docs, fix factual drift

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/skills/langfuse/references/v4-project-migration.md
+++ b/skills/langfuse/references/v4-project-migration.md
@@ -84,7 +84,7 @@ If the available project interface cannot read or update a legacy rule, provide 
 
 ## 6. Migrate exports
 
-Changing the export source is a breaking change for every downstream consumer, not a settings toggle. Fetch the documented upgrade paths and follow them instead of restating export mechanics from memory:
+Switching an integration to enriched-only output is a breaking change for downstream consumers; enabling the dual source (legacy plus enriched observations) is additive and safe. Fetch the documented upgrade paths and follow them instead of restating export mechanics from memory:
 
 - [Blob Storage upgrade path](https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage#upgrade-path) and the [enriched vs. legacy field differences](https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-vs-legacy-differences)
 - [Mixpanel export migration](https://langfuse.com/integrations/analytics/mixpanel#export-source-fast-preview-langfuse-v4)
@@ -94,15 +94,15 @@ Key takeaways:
 
 - Inventory configured Blob Storage, Mixpanel, PostHog, and other export integrations in **Project Settings > Integrations**.
 - Check eligibility first: many integrations can no longer select legacy sources (Langfuse Cloud date cutoffs; self-hosted deployments that completed the v4 migration — see the docs for the exact rules). An integration that already exports enriched observations only is complete by default.
-- Follow the documented dual-export transition per integration: switch to legacy plus enriched observations, validate downstream consumers, then switch to enriched observations only. Never switch a legacy integration directly to enriched-only while downstream consumers are unvalidated.
+- Follow the documented dual-export transition per integration. Switching from legacy to legacy plus enriched observations is additive and needs no downstream sign-off — apply it directly. The switch from the dual source to enriched observations only stops the legacy output and requires the user's explicit confirmation that downstream owners are prepared. Never switch a legacy integration directly to enriched-only.
 - A source change applies to future exports only; already-exported history keeps the legacy shape and is not re-exported.
 - Change only the export source. Leave credentials, schedules, prefixes, file formats, field groups, and integration secrets untouched. Apply the change in the integration settings UI — for Blob Storage the documented public API (project-scoped keys) also works; Mixpanel and PostHog have no API migration path.
 
-Effects outside Langfuse — spell these out per configured integration and obtain the user's explicit confirmation that downstream owners are prepared before changing anything:
+Effects outside Langfuse — spell these out per configured integration before the enriched-only cutover:
 
 - **Blob Storage:** the exported tables, file paths, and column sets change (scores are unaffected). Warehouse loaders, table schemas, trace-observation joins, dashboards, and any storage-event automation keyed on the legacy file paths must be updated — the integration setting is the smallest part of the migration. After the switch the legacy directories receive no further files, so pipelines still watching them go silent without an error signal.
 - **Mixpanel and PostHog:** the source determines which events and properties are sent, so dashboards, transformations, funnels, and alerts built on the legacy events in those systems must be revalidated.
-- **Dual mode** creates duplicate records by design: counts, costs, and metrics in downstream systems are inflated until consumers deduplicate or the transition completes.
+- **Dual mode** exports the same data in both the legacy and the enriched shape by design. Downstream counts, costs, and metrics are inflated only where a consumer ingests both — for example a warehouse model loading both observation tables, or analytics queries matching both event sets. Keep each consumer on exactly one shape during the transition.
 - Because history is not re-exported, downstream consumers must either keep handling the legacy schema for historical data or the user must re-export history as documented.
 - Treat the downstream consumer update as part of the migration. Report this area as `manual action`, not `ready`, until the user confirms consumers handle the new schema.
 

--- a/skills/langfuse/references/v4-project-migration.md
+++ b/skills/langfuse/references/v4-project-migration.md
@@ -84,18 +84,27 @@ If the available project interface cannot read or update a legacy rule, provide 
 
 ## 6. Migrate exports
 
-Changing the export source is a breaking change for every downstream consumer, not a settings toggle. Before proposing or making any source change, explain the concrete consequences for each configured integration and obtain the user's explicit confirmation that downstream owners are prepared.
+Changing the export source is a breaking change for every downstream consumer, not a settings toggle. Fetch the documented upgrade paths and follow them instead of restating export mechanics from memory:
+
+- [Blob Storage upgrade path](https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage#upgrade-path) and the [enriched vs. legacy field differences](https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-vs-legacy-differences)
+- [Mixpanel export migration](https://langfuse.com/integrations/analytics/mixpanel#export-source-fast-preview-langfuse-v4)
+- [PostHog export migration](https://langfuse.com/integrations/analytics/posthog#export-source-fast-preview-langfuse-v4)
+
+Key takeaways:
 
 - Inventory configured Blob Storage, Mixpanel, PostHog, and other export integrations in **Project Settings > Integrations**.
-- Spell out what the source change does per integration before touching it:
-  - **Blob Storage:** the exported tables and file paths change. Legacy writes `traces` and `observations` files; enriched writes `observations_v2` under a new directory prefix, and the separate `traces` file is no longer produced in enriched-only mode. Column sets differ per the [export field reference](https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-vs-legacy-differences), so loaders, warehouse table schemas, trace-observation joins, and dashboards across the full data pipeline must be updated — not just the integration setting.
-  - **Mixpanel and PostHog:** the source determines which events and properties are sent, so dashboards, transformations, funnels, and alerts built on the legacy events in those systems are affected and must be revalidated.
-  - **Dual mode** (`legacy and enriched observations`) creates duplicate records by design. Warn that counts, costs, and metrics in downstream systems will be inflated until consumers deduplicate or the transition completes.
-- For Blob Storage, inspect or update the integration through the API when organization-scoped credentials and the current schema are available. Otherwise direct the user to [Blob Storage settings](https://cloud.langfuse.com/project/~/settings/integrations/blobstorage).
-- For Mixpanel and PostHog, use the UI and the linked migration guides. Do not claim an API migration path that the current interface does not provide.
-- Follow the documented dual-export transition: enable legacy plus enriched observations, update and validate downstream consumers against the field reference, then switch to enriched observations only. Never switch a legacy integration directly to enriched-only while downstream consumers are unvalidated.
-- Do not overwrite bucket credentials, schedules, prefixes, file formats, field groups, or integration secrets while changing the export source.
-- Treat the downstream consumer update as part of the migration. A source toggle without validating queries, joins, dashboards, and field parsing is incomplete; report this area as `manual action`, not `ready`, until the user confirms consumers handle the new schema.
+- Check eligibility first: Cloud projects created on or after 2026-05-20 already export enriched observations only and cannot select legacy sources — for them this step is complete by default.
+- Follow the documented dual-export transition per integration: switch to legacy plus enriched observations, validate downstream consumers, then switch to enriched observations only. Never switch a legacy integration directly to enriched-only while downstream consumers are unvalidated.
+- A source change applies to future exports only; already-exported history keeps the legacy shape and is not re-exported.
+- Change only the export source. Leave credentials, schedules, prefixes, file formats, field groups, and integration secrets untouched. Apply the change in the integration settings UI — for Blob Storage the documented public API (project-scoped keys) also works; Mixpanel and PostHog have no API migration path.
+
+Effects outside Langfuse — spell these out per configured integration and obtain the user's explicit confirmation that downstream owners are prepared before changing anything:
+
+- **Blob Storage:** the exported tables, file paths, and column sets change (scores are unaffected). Warehouse loaders, table schemas, trace-observation joins, dashboards, and any storage-event automation keyed on the legacy file paths must be updated — the integration setting is the smallest part of the migration.
+- **Mixpanel and PostHog:** the source determines which events and properties are sent, so dashboards, transformations, funnels, and alerts built on the legacy events in those systems must be revalidated.
+- **Dual mode** creates duplicate records by design: counts, costs, and metrics in downstream systems are inflated until consumers deduplicate or the transition completes.
+- Because history is not re-exported, downstream consumers must either keep handling the legacy schema for historical data or the user must re-export history as documented.
+- Treat the downstream consumer update as part of the migration. Report this area as `manual action`, not `ready`, until the user confirms consumers handle the new schema.
 
 ## 7. Report readiness
 

--- a/skills/langfuse/references/v4-project-migration.md
+++ b/skills/langfuse/references/v4-project-migration.md
@@ -93,14 +93,14 @@ Changing the export source is a breaking change for every downstream consumer, n
 Key takeaways:
 
 - Inventory configured Blob Storage, Mixpanel, PostHog, and other export integrations in **Project Settings > Integrations**.
-- Check eligibility first: Cloud projects created on or after 2026-05-20 already export enriched observations only and cannot select legacy sources — for them this step is complete by default.
+- Check eligibility first: many integrations can no longer select legacy sources (Langfuse Cloud date cutoffs; self-hosted deployments that completed the v4 migration — see the docs for the exact rules). An integration that already exports enriched observations only is complete by default.
 - Follow the documented dual-export transition per integration: switch to legacy plus enriched observations, validate downstream consumers, then switch to enriched observations only. Never switch a legacy integration directly to enriched-only while downstream consumers are unvalidated.
 - A source change applies to future exports only; already-exported history keeps the legacy shape and is not re-exported.
 - Change only the export source. Leave credentials, schedules, prefixes, file formats, field groups, and integration secrets untouched. Apply the change in the integration settings UI — for Blob Storage the documented public API (project-scoped keys) also works; Mixpanel and PostHog have no API migration path.
 
 Effects outside Langfuse — spell these out per configured integration and obtain the user's explicit confirmation that downstream owners are prepared before changing anything:
 
-- **Blob Storage:** the exported tables, file paths, and column sets change (scores are unaffected). Warehouse loaders, table schemas, trace-observation joins, dashboards, and any storage-event automation keyed on the legacy file paths must be updated — the integration setting is the smallest part of the migration.
+- **Blob Storage:** the exported tables, file paths, and column sets change (scores are unaffected). Warehouse loaders, table schemas, trace-observation joins, dashboards, and any storage-event automation keyed on the legacy file paths must be updated — the integration setting is the smallest part of the migration. After the switch the legacy directories receive no further files, so pipelines still watching them go silent without an error signal.
 - **Mixpanel and PostHog:** the source determines which events and properties are sent, so dashboards, transformations, funnels, and alerts built on the legacy events in those systems must be revalidated.
 - **Dual mode** creates duplicate records by design: counts, costs, and metrics in downstream systems are inflated until consumers deduplicate or the transition completes.
 - Because history is not re-exported, downstream consumers must either keep handling the legacy schema for historical data or the user must re-export history as documented.


### PR DESCRIPTION
## Summary

Reworks section 6 ("Migrate exports") of `skills/langfuse/references/v4-project-migration.md` to follow the repo principle that skill content should defer to the docs. The section now contains only:

- **references** into the documented upgrade paths (Blob Storage, Mixpanel, PostHog),
- the **decision-relevant takeaways** an agent needs before touching anything,
- **warnings about effects outside Langfuse** — the customer's warehouse loaders, dashboards, funnels, alerts, and storage-event automation.

## Corrections against the current docs

Verified against the langfuse.com docs (export-to-blob-storage, blob-storage-export-fields, PostHog/Mixpanel integration pages):

- The Blob Storage integration API (`GET`/`PUT /api/public/integrations/blob-storage`) authenticates with **project-scoped** API keys — the old text claimed organization-scoped credentials.
- Added an **eligibility gate**: many integrations can no longer select legacy sources (Cloud date cutoffs, self-hosted deployments that completed the v4 migration), so the dual-export transition doesn't apply to them and the step is complete by default. Stated generically with a pointer to the docs, since the exact cutoff rules have already changed once.
- Added that a source change applies to **future exports only** — already-exported history keeps the legacy shape unless the user re-exports, so downstream consumers must plan for both schemas on historical data.
- Added that after the switch, legacy directories receive **no further files**, so pipelines watching them go silent without an error signal.
- Noted that **scores exports are unaffected** by the source change.
- Removed inline restated mechanics (file paths, column behavior) now covered by the doc links.

Patch version bump `1.4.0` → `1.4.1` in both plugin manifests per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)