### PR TITLE
docs: update analytics export anchors for restructured integration pages

### DIFF
--- a/skills/langfuse/references/v4-project-migration.md
+++ b/skills/langfuse/references/v4-project-migration.md
@@ -23,8 +23,8 @@ Fetch the applicable pages before taking action:
 - [Evaluation Rules API](https://api.reference.langfuse.com/#tag/unstableevaluationrules)
 - [Blob storage export migration](https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage#export-source-fast-preview)
 - [Export field reference](https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-vs-legacy-differences)
-- [Mixpanel export migration](https://langfuse.com/integrations/analytics/mixpanel#export-source-fast-preview-langfuse-v4)
-- [PostHog export migration](https://langfuse.com/integrations/analytics/posthog#export-source-fast-preview-langfuse-v4)
+- [Mixpanel export migration](https://langfuse.com/integrations/analytics/mixpanel#migrate-export-source)
+- [PostHog export migration](https://langfuse.com/integrations/analytics/posthog#migrate-export-source)
 
 Discover the current API or tool schema before writes; the evaluator endpoints are unstable.
 
@@ -87,8 +87,8 @@ If the available project interface cannot read or update a legacy rule, provide 
 Switching an integration to enriched-only output is a breaking change for downstream consumers; enabling the dual source (legacy plus enriched observations) is additive and safe. Fetch the documented upgrade paths and follow them instead of restating export mechanics from memory:
 
 - [Blob Storage upgrade path](https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage#upgrade-path) and the [enriched vs. legacy field differences](https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-vs-legacy-differences)
-- [Mixpanel export migration](https://langfuse.com/integrations/analytics/mixpanel#export-source-fast-preview-langfuse-v4)
-- [PostHog export migration](https://langfuse.com/integrations/analytics/posthog#export-source-fast-preview-langfuse-v4)
+- [Mixpanel export migration](https://langfuse.com/integrations/analytics/mixpanel#migrate-export-source) and the [legacy vs. enriched event changes](https://langfuse.com/integrations/analytics/mixpanel#legacy-vs-enriched)
+- [PostHog export migration](https://langfuse.com/integrations/analytics/posthog#migrate-export-source) and the [legacy vs. enriched event changes](https://langfuse.com/integrations/analytics/posthog#legacy-vs-enriched)
 
 Key takeaways:
 


### PR DESCRIPTION
The PostHog and Mixpanel integration pages are being restructured v4-first in [langfuse-docs#3360](https://github.com/langfuse/langfuse-docs/pull/3360): the old "Export source (Fast Preview, Langfuse v4)" section became a "Legacy export sources" section at the bottom of each page, so the `#export-source-fast-preview-langfuse-v4` anchor these references link to no longer exists (links currently land at the top of the page).

Changes to `skills/langfuse/references/v4-project-migration.md`:

- Point the four Mixpanel/PostHog migration links (Sources of truth + step 6) at the new explicit `#migrate-export-source` anchor.
- Add `#legacy-vs-enriched` links in step 6 — the analytics counterpart of the blob-storage "enriched vs. legacy field differences" link that was already there, giving agents the exact event/property diff when revalidating dashboards built on legacy events.

⚠️ Depends on langfuse-docs#3360 being merged and deployed — the new anchors don't exist on langfuse.com until then. Keep as draft until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)