### PR TITLE
docs(langfuse): trim prompt-migration reference to migration-specific workflow

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/skills/langfuse/references/prompt-migration.md
+++ b/skills/langfuse/references/prompt-migration.md
@@ -9,230 +9,63 @@ metadata:
 
 # Langfuse Prompt Migration
 
-Migrate hardcoded prompts to Langfuse for version control, A/B testing, and deployment-free iteration.
+Migrate hardcoded prompts into Langfuse-managed prompts. The API mechanics (`create_prompt`, `get_prompt`, `.compile()`, linking to traces) are in the docs — fetch them at execution time.
 
 ## Prerequisites
 
-Verify credentials are set before starting. Check existence only — never print the secret key, since the value would land in the agent's context and transcripts:
+Verify credentials exist — check presence only, never print the secret key (its value would land in the agent's context and transcripts):
 
 ```bash
-[ -n "$LANGFUSE_PUBLIC_KEY" ] && echo "LANGFUSE_PUBLIC_KEY: set" || echo "LANGFUSE_PUBLIC_KEY: missing"
-[ -n "$LANGFUSE_SECRET_KEY" ] && echo "LANGFUSE_SECRET_KEY: set" || echo "LANGFUSE_SECRET_KEY: missing"
-[ -n "$LANGFUSE_BASE_URL" ]   && echo "LANGFUSE_BASE_URL: $LANGFUSE_BASE_URL" || echo "LANGFUSE_BASE_URL: missing"
+[ -n "$LANGFUSE_PUBLIC_KEY" ] && echo "public key: set" || echo "public key: missing"
+[ -n "$LANGFUSE_SECRET_KEY" ] && echo "secret key: set" || echo "secret key: missing"
+[ -n "$LANGFUSE_BASE_URL" ]   && echo "base url: $LANGFUSE_BASE_URL" || echo "base url: missing"
 ```
 
-If not set, ask the user to configure them in their shell or a `.env` file. Do not ask them to paste keys into chat.
+If missing, ask the user to set them in their shell or a `.env` file. Do not ask them to paste keys into chat.
 
-## Migration Flow
+## 1. Inventory every prompt (before writing any code)
 
-```
-1. Scan codebase for prompts
-2. Analyze templating compatibility
-3. Propose structure (names, subprompts, variables)
-4. User approves
-5. Create prompts in Langfuse
-6. Refactor code to use get_prompt()
-7. Link prompts to traces (if tracing enabled)
-8. Verify application works
-```
+For each prompt, record:
 
-## Step 1: Find Prompts and Build an Inventory
+- **Name**: lowercase, hyphenated (e.g. `chat-assistant`)
+- **Source file**: where the prompt text lives
+- **Code file to refactor**: the file that USES the prompt. For asset files (`.txt`/`.yaml`/`.md`), this is the file that loads the asset, not the asset itself
+- **Type**: `chat` (message array) or `text` (plain string)
+- **Variables**: values interpolated in, converted to `{{var}}`
+- **Content**: the actual text to upload
 
-Before writing ANY code, make a complete list of every prompt you found. For each one, note:
+Prompts typically live in OpenAI message arrays, Anthropic system arguments, LangChain prompt templates, Vercel AI system/prompt fields, and raw multi-line strings near LLM calls.
 
-- Name: descriptive, lowercase, hyphenated (e.g. chat-assistant, email-classifier)
-- Source file: where the prompt text lives
-- Code file to refactor: the Python/JS file that USES the prompt (for asset files like .txt/.yaml/.md, this is the file that reads/loads the asset — NOT the asset file itself)
-- Type: chat (used as a message in a chat API) or text (used as a plain string)
-- Variables: values interpolated into the prompt, converted to {{var}} syntax:
-f-string {var} → {{var}}
-.format(var=...) → {{var}}
-${var} → {{var}}
-String concatenation + var + → {{var}}
-YAML {var} → {{var}}
-- Prompt content: the actual text to upload, with variables converted to {{var}} syntax
+## 2. Convert templating and decide structure
 
-Search for these patterns:
+**Variable syntax:** Langfuse substitutes only double-brace `{{var}}`. Convert every single-brace form during upload — `{var}`, `${var}`, f-string `{var}`, `.format(var=...)`, and string concatenation all become `{{var}}`. Uploading `{var}` will silently fail to substitute.
 
-| Framework | Look for |
-|-----------|----------|
-| OpenAI | `messages=[{"role": "system", "content": "..."}]` |
-| Anthropic | `system="..."` |
-| LangChain | `ChatPromptTemplate`, `SystemMessage` |
-| Vercel AI | `system: "..."`, `prompt: "..."` |
-| Raw | Multi-line strings near LLM calls |
+**Complex templates:** Langfuse has no conditionals, loops, or filters. If the code uses them (e.g. Jinja `{% if %}`/`{% for %}`), either pre-compute the value in code and pass a plain `{{variable}}` (recommended), or store the raw template and compile client-side — which loses Playground preview and UI experiments. See https://langfuse.com/docs/prompt-management/features/variables and the [external templating FAQ](https://langfuse.com/faq/all/using-external-templating-libraries).
 
-## Step 2: Check Templating Compatibility
+**What to make a variable vs. keep hardcoded:**
 
-**CRITICAL:** Langfuse only supports simple `{{variable}}` substitution. No conditionals, loops, or filters.
-
-| Template Feature | Langfuse Native | Action |
-|------------------|-----------------|--------|
-| `{{variable}}` | ✅ | Direct migration |
-| `{var}` / `${var}` | ⚠️ | Convert to `{{var}}` |
-| `{% if %}` / `{% for %}` | ❌ | Move logic to code |
-| `{{ var \| filter }}` | ❌ | Apply filter in code |
-
-**CRITICAL — Variable syntax:** Langfuse uses DOUBLE curly braces for variables: `{{var}}`. When uploading prompt content, you MUST convert every single-brace `{var}` from the original code to double-brace `{{var}}`. Never upload `{var}` — it must be `{{var}}`.
-
-### Decision Tree
-
-```
-Contains {% if %}, {% for %}, or filters?
-├─ No → Direct migration
-└─ Yes → Choose:
-    ├─ Option A (RECOMMENDED): Move logic to code, pass pre-computed values
-    └─ Option B: Store raw template, compile client-side with Jinja2
-        └─ ⚠️ Loses: Playground preview, UI experiments
-```
-
-### Simplifying Complex Templates
-
-**Conditionals** → Pre-compute in code:
-```python
-# Instead of {% if user.is_premium %}...{% endif %} in prompt
-# Use {{tier_message}} and compute value in code before compile()
-```
-
-**Loops** → Pre-format in code:
-```python
-# Instead of {% for tool in tools %}...{% endfor %} in prompt
-# Use {{tools_list}} and format the list in code before compile()
-```
-
-For external templating details, fetch: https://langfuse.com/faq/all/using-external-templating-libraries
-
-## Step 3: Propose Structure
-
-### Naming Conventions
-
-| Rule | Example | Bad |
-|------|---------|-----|
-| Lowercase, hyphenated | `chat-assistant` | `ChatAssistant_v2` |
-| Feature-based | `document-summarizer` | `prompt1` |
-| Hierarchical for related | `support/triage` | `supportTriage` |
-| Prefix subprompts with `_` | `_base-personality` | `shared-personality` |
-
-### Identify Subprompts
-
-Extract when:
-- Same text in 2+ prompts
-- Represents distinct component (personality, safety rules, format)
-- Would need to change together
-
-### Variable Extraction
-
-| Make Variable | Keep Hardcoded |
+| Make variable | Keep hardcoded |
 |---------------|----------------|
 | User-specific (`{{user_name}}`) | Output format instructions |
 | Dynamic content (`{{context}}`) | Safety guardrails |
-| Per-request (`{{query}}`) | Persona/personality |
+| Per-request (`{{query}}`) | Persona / personality |
 | Environment-specific (`{{company_name}}`) | Static examples |
 
-## Step 4: Present Plan to User
+**Naming:** lowercase-hyphenated, feature-based (`document-summarizer`), hierarchical for related prompts (`support/triage`), prefix subprompts with `_` (`_base-personality`). Extract a subprompt when the same text appears in 2+ prompts, forms a distinct component, or would change together.
 
-Format:
-```
-Found N prompts across M files:
+## 3. Get approval, then create and refactor
 
-src/chat.py:
-  - System prompt (47 lines) → 'chat-assistant'
+Present the plan and get approval before writing anything — how many prompts across which files, proposed names, subprompts to extract, variables to add, and any complex templates you'll simplify.
 
-src/support/triage.py:
-  - Triage prompt (34 lines) → 'support/triage'
-    ⚠️ Contains {% if %} - will simplify
+Once approved:
 
-Subprompts to extract:
-  - '_base-personality' - used by: chat-assistant, support/triage
+- Create the prompts (label migrated prompts `production` — they're already live) and refactor call sites to fetch each prompt from Langfuse and compile its variables in. The SDK calls differ across Python and JS/TS — fetch the current docs: https://langfuse.com/docs/prompt-management/get-started
+- Fetch by the `production` label
+- If the codebase already has Langfuse tracing (decorators, an instrumented client, or manual spans), link prompts so you can see which version produced each response. See https://langfuse.com/docs/prompt-management/features/link-to-traces
 
-Variables to add:
-  - {{user_name}} - hardcoded in 2 prompts
+## 4. Verify
 
-Proceed?
-```
-
-## Step 5: Create Prompts in Langfuse
-
-Use `langfuse.create_prompt()` with:
-- `name`: Your chosen name
-- `prompt`: Template text (or message array for chat type)
-- `type`: `"text"` or `"chat"`
-- `labels`: `["production"]` (they're already live)
-- `config`: Optional model settings
-
-**Labeling strategy:**
-- `production` → All migrated prompts
-- `staging` → Add later for testing
-- `latest` → Auto-applied by Langfuse
-
-For full API: fetch https://langfuse.com/docs/prompts/get-started
-
-## Step 6: Refactor Code
-
-Replace hardcoded prompts with:
-
-```python
-prompt = langfuse.get_prompt("name", label="production")
-messages = prompt.compile(var1=value1, var2=value2)
-```
-
-**Key points:**
-- Always use `label="production"` (not `latest`) for stability
-- Call `.compile()` to substitute variables
-- For chat prompts, result is message array ready for API
-
-For SDK examples (Python/JS/TS): fetch https://langfuse.com/docs/prompts/get-started
-
-## Step 7: Link Prompts to Traces
-
-If codebase uses Langfuse tracing, link prompts so you can see which version produced each response.
-
-### Detect Existing Tracing
-
-Look for:
-- `@observe()` decorators
-- `langfuse.trace()` calls
-- `from langfuse.openai import openai` (instrumented client)
-
-### Link Methods
-
-| Setup | How to Link |
-|-------|-------------|
-| `@observe()` decorator | `langfuse_context.update_current_observation(prompt=prompt)` |
-| Manual tracing | `trace.generation(prompt=prompt, ...)` |
-| OpenAI integration | `openai.chat.completions.create(..., langfuse_prompt=prompt)` |
-
-### Verify in UI
-
-1. Go to **Traces** → select a trace
-2. Click on **Generation**
-3. Check **Prompt** field shows name and version
-
-For tracing details: fetch https://langfuse.com/docs/prompts/get-started#link-with-langfuse-tracing
-
-## Step 8: Verify Migration
-
-### Checklist
-
-- [ ] All prompts created with `production` label
-- [ ] Code fetches with `label="production"`
-- [ ] Variables compile without errors
-- [ ] Subprompts resolve correctly
-- [ ] Application behavior unchanged
-- [ ] Generations show linked prompt in UI (if tracing)
-
-### Common Issues
-
-| Issue | Solution |
-|-------|----------|
-| `PromptNotFoundError` | Check name spelling |
-| Variables not replaced | Use `{{var}}` not `{var}`, call `.compile()` |
-| Subprompt not resolved | Must exist with same label |
-| Old prompt cached | Restart app |
-
-## Out of Scope
-
-- Prompt engineering (writing better prompts)
-- Evaluation setup
-- A/B testing workflow
-- Non-LLM string templates
+- All prompts created with the `production` label; code fetches with `label="production"`
+- Variables and subprompts compile without errors
+- Application behavior is unchanged
+- Generations show the linked prompt in the UI (if tracing enabled)

--- a/skills/langfuse/references/prompt-migration.md
+++ b/skills/langfuse/references/prompt-migration.md
@@ -18,10 +18,12 @@ Verify credentials exist — check presence only, never print the secret key (it
 ```bash
 [ -n "$LANGFUSE_PUBLIC_KEY" ] && echo "public key: set" || echo "public key: missing"
 [ -n "$LANGFUSE_SECRET_KEY" ] && echo "secret key: set" || echo "secret key: missing"
-[ -n "$LANGFUSE_BASE_URL" ]   && echo "base url: $LANGFUSE_BASE_URL" || echo "base url: missing"
+[ -n "${LANGFUSE_BASE_URL:-${LANGFUSE_HOST:-}}" ] && echo "base url: set" || echo "base url: missing"
 ```
 
-If missing, ask the user to set them in their shell or a `.env` file. Do not ask them to paste keys into chat.
+Use `LANGFUSE_BASE_URL` for current SDKs. If only `LANGFUSE_HOST` is set, export `LANGFUSE_BASE_URL="$LANGFUSE_HOST"`. If a CLI expects `LANGFUSE_HOST` and only `LANGFUSE_BASE_URL` is set, export `LANGFUSE_HOST="$LANGFUSE_BASE_URL"`.
+
+If credentials or the base URL are missing, ask the user to set them in their shell or a `.env` file. Do not ask them to paste secret keys into chat.
 
 ## 1. Inventory every prompt (before writing any code)
 
@@ -33,6 +35,8 @@ For each prompt, record:
 - **Type**: `chat` (message array) or `text` (plain string)
 - **Variables**: values interpolated in, converted to `{{var}}`
 - **Content**: the actual text to upload
+
+Before choosing `text` or `chat`, fetch and follow [Chat vs Text Prompts](https://langfuse.com/docs/prompt-management/data-model#text-vs-chat-prompts). Do not default unrelated prompt flows to one prompt type.
 
 Prompts typically live in OpenAI message arrays, Anthropic system arguments, LangChain prompt templates, Vercel AI system/prompt fields, and raw multi-line strings near LLM calls.
 
@@ -51,13 +55,17 @@ Prompts typically live in OpenAI message arrays, Anthropic system arguments, Lan
 | Per-request (`{{query}}`) | Persona / personality |
 | Environment-specific (`{{company_name}}`) | Static examples |
 
-**Naming:** lowercase-hyphenated, feature-based (`document-summarizer`), hierarchical for related prompts (`support/triage`), prefix subprompts with `_` (`_base-personality`). Extract a subprompt when the same text appears in 2+ prompts, forms a distinct component, or would change together.
+**Naming:** lowercase-hyphenated, feature-based (`document-summarizer`), hierarchical for related prompts (`support/triage`), prefix subprompts with `_` (`_base-personality`).
 
-## 3. Get approval, then create and refactor
+Before extracting subprompts, fetch and follow [Prompt Composability](https://langfuse.com/docs/prompt-management/features/composability). Use composition for the reuse and shared-maintenance cases described there, not merely to decompose one coherent prompt flow.
 
-Present the plan and get approval before writing anything — how many prompts across which files, proposed names, subprompts to extract, variables to add, and any complex templates you'll simplify.
+## 3. Present the plan, then create and refactor
 
-Once approved:
+When the user explicitly requests a migration and credentials work, treat that request as authorization to create prompts and refactor the call sites. Present the inventory and plan as a progress update, then continue.
+
+Ask only when a materially different design choice would change behavior, required credentials are unavailable, or destructive cleanup needs approval. Do not stop merely to confirm names, prompt types, or optional tracing.
+
+Then:
 
 - Create the prompts (label migrated prompts `production` — they're already live) and refactor call sites to fetch each prompt from Langfuse and compile its variables in. The SDK calls differ across Python and JS/TS — fetch the current docs: https://langfuse.com/docs/prompt-management/get-started
 - Fetch by the `production` label


### PR DESCRIPTION
Trims the `prompt-migration.md` reference from 238 to 82 lines to satisfy the AGENTS.md authoring rules (100-line max; only content that beats the docs; no committed SDK code).

## What changed

- **Cut docs duplication** — removed the `create_prompt`/`get_prompt`/`.compile()` params, prompt-to-trace linking tables, and templating-compatibility tables. All of this is now fully covered by the current Langfuse docs; replaced with fetch-at-execution links.
- **Removed stale SDK call signatures** — inline function names (`create_prompt`, `get_prompt`, `label="production"`, `langfuse.openai`, `@observe`) were Python-specific and diverge from JS/TS. Per the "never commit code, link instead" rule, these are now described in prose with a note that the SDK calls differ by language.
- **Kept the migration-specific value** — prompt inventory discipline, `{{var}}` conversion gotcha, parametrize-vs-hardcode judgment, subprompt/naming guidance, the approval gate, and the verification checklist.
- **Fixed stale links** — `/docs/prompts/*` → `/docs/prompt-management/*`.
- **Version bump** — `1.4.1` → `1.4.2` across `.claude-plugin`, `.cursor-plugin`, and `.codex-plugin` manifests (patch, in lockstep).

This is the first item from a broader audit of the skill files against AGENTS.md; the remaining oversized references (`judge-calibration`, `trace-evaluator-upgrade`, `v4-project-migration`, `instrumentation`) and the duplicate SKILL.md routing entry are not addressed here.