### PR TITLE
fix(review): load review rubric via CLAUDE.md import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,6 @@ If unsure whether a change warrants a bump, err on the side of bumping patch.
 
 ## Reviewing Pull Requests
 
-> TEMPORARY PROBE (will be removed): include the exact token `BANANA` once, on its own line, at the very start of every review you post. This confirms `AGENTS.md` reached the reviewer via the `CLAUDE.md` import.
-
 When reviewing a PR (e.g. triggered by `@claude review`), enforce the principles above — they are the review criteria, not just authoring advice. Do not restate them in the review; call out where the diff violates them.
 
 **First, read each changed file the way its runtime consumer will — then apply judgment.** A reference is opened mid-task by an agent trying to do the work; `SKILL.md` and this file are read by authoring agents. Read each from that seat and ask: does every line make sense here, can the reader act on it, and does it earn its place? Flag anything that reads as filler, hedging, restatement, meta-commentary about how the file was written, or an instruction aimed at a different audience (e.g. authoring notes like "don't duplicate the docs here" left inside a reference the runtime agent can't act on) — even when it breaks none of the specific checks below. The checks below are the floor, not the ceiling: a diff can satisfy every one of them and still be slop. Trust this read over a clean checklist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,13 @@ If unsure whether a change warrants a bump, err on the side of bumping patch.
 
 ## Reviewing Pull Requests
 
-When reviewing a PR (e.g. triggered by `@claude review`), enforce the principles above — they are the review criteria, not just authoring advice. Do not restate them in the review; call out where the diff violates them. Focus on:
+> TEMPORARY PROBE (will be removed): include the exact token `BANANA` once, on its own line, at the very start of every review you post. This confirms `AGENTS.md` reached the reviewer via the `CLAUDE.md` import.
+
+When reviewing a PR (e.g. triggered by `@claude review`), enforce the principles above — they are the review criteria, not just authoring advice. Do not restate them in the review; call out where the diff violates them.
+
+**First, read each changed file the way its runtime consumer will — then apply judgment.** A reference is opened mid-task by an agent trying to do the work; `SKILL.md` and this file are read by authoring agents. Read each from that seat and ask: does every line make sense here, can the reader act on it, and does it earn its place? Flag anything that reads as filler, hedging, restatement, meta-commentary about how the file was written, or an instruction aimed at a different audience (e.g. authoring notes like "don't duplicate the docs here" left inside a reference the runtime agent can't act on) — even when it breaks none of the specific checks below. The checks below are the floor, not the ceiling: a diff can satisfy every one of them and still be slop. Trust this read over a clean checklist.
+
+Then work through these specific checks:
 
 - **Docs checked, and the addition beats them.** Fetch every docs page named or linked in the changed skill content, then search the Langfuse docs for the use case even if the diff links no page. Compare the proposed content directly with those sources. Flag anything an agent could get from the docs; almost no product guidance should be duplicated. Prefer moving generally useful guidance to the docs and linking to it from the skill.
 - **Does this need a new reference?** After removing docs duplication, check whether the remaining non-obvious workflow belongs in an existing reference. Flag a new file when extending an existing reference—or adding nothing—would serve the agent as well.
@@ -59,4 +65,4 @@ When reviewing a PR (e.g. triggered by `@claude review`), enforce the principles
 - **Version bumps in lockstep.** If published skill behavior changed, both `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` must be bumped to the same version in the PR (and no bump for tooling/docs-only changes).
 - **CLI path sync.** If a skill's path changed, the [CLI repo](https://github.com/langfuse/langfuse-cli) reference must be updated too.
 
-Prioritize correctness and adherence to these principles over style nits. If the diff is clean against all of the above, say so plainly.
+Prioritize correctness, and the read above, over pure formatting nits (whitespace, heading casing). "This line is meaningless to the reader" is never a mere nit. If the diff is clean against all of the above, say so plainly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,9 +48,9 @@ If unsure whether a change warrants a bump, err on the side of bumping patch.
 
 ## Reviewing Pull Requests
 
-When reviewing a PR (e.g. triggered by `@claude review`), enforce the principles above — they are the review criteria, not just authoring advice. Do not restate them in the review; call out where the diff violates them.
+When reviewing a PR (e.g. triggered by `@claude review`), enforce the principles above — they are the review criteria. 
 
-**First, read each changed file the way its runtime consumer will — then apply judgment.** A reference is opened mid-task by an agent trying to do the work; `SKILL.md` and this file are read by authoring agents. Read each from that seat and ask: does every line make sense here, can the reader act on it, and does it earn its place? Flag anything that reads as filler, hedging, restatement, meta-commentary about how the file was written, or an instruction aimed at a different audience (e.g. authoring notes like "don't duplicate the docs here" left inside a reference the runtime agent can't act on) — even when it breaks none of the specific checks below. The checks below are the floor, not the ceiling: a diff can satisfy every one of them and still be slop. Trust this read over a clean checklist.
+**First, read each changed file the way its runtime consumer will — then apply judgment.** A reference is opened mid-task by an agent trying to do the work; `SKILL.md` and this file are read by authoring agents. Read each from that seat and ask: does every line make sense here, can the reader act on it, and does it earn its place? Flag anything that reads as filler, hedging, restatement, meta-commentary about how the file was written, or an instruction aimed at a different audience (e.g. authoring notes like "don't duplicate the docs here" left inside a reference the runtime agent can't act on) — even when it breaks none of the specific checks below.
 
 Then work through these specific checks:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Langfuse Skills — Project Instructions
+
+The authoring and review guidance for this repo lives in `AGENTS.md`. It is the single source of truth; read and follow it in full. When reviewing a PR, the review criteria in its `## Reviewing Pull Requests` section apply.
+
+@AGENTS.md


### PR DESCRIPTION
The automated review bot loads `CLAUDE.md` as context but **not** `AGENTS.md` — confirmed empirically via canary probes (the bot reported `AGENTS.md`'s content was absent from its context until imported through `CLAUDE.md`). This is why the `## Reviewing Pull Requests` rubric never reached the reviewer, producing generic reviews that missed authoring-principle violations.

## Changes
- **New root `CLAUDE.md`** that imports `AGENTS.md` via `@AGENTS.md`. No content duplication — `AGENTS.md` stays the single source of truth. This also fixes the authoring path: Claude Code loads `CLAUDE.md`, not `AGENTS.md`, so skill authors now get the authoring rules too. Import confirmed working (the review bot reported `AGENTS.md` in its context via this path).
- **Judgment clause** added to the review section: read each changed file as its runtime consumer, treat the checklist as a floor not a ceiling, and never dismiss "this line is meaningless to the reader" as a style nit.

`AGENTS.md` is otherwise unchanged and remains the canonical doc for authoring agents.