### PR TITLE
Clarify Langfuse credential preflight

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -71,7 +71,7 @@ export LANGFUSE_SECRET_KEY=sk-lf-...
 export LANGFUSE_BASE_URL=https://cloud.langfuse.com # example for EU cloud. For US cloud it's us.cloud.langfuse.com, and can also be a self-hosted URL. The server must always be specified in order to access Langfuse.
 ```
 If `LANGFUSE_BASE_URL` is used instead of `LANGFUSE_HOST`, run `export LANGFUSE_HOST="$LANGFUSE_BASE_URL"`.
-If not set, ask the user to set them in their shell or a `.env` file (do not ask them to paste keys into chat for security reasons). Keys are found in Langfuse UI → Settings → API Keys.
+If not set, ask the user to set them in their shell or a `.env` file. Keys are found in the Langfuse project under Settings -> API Keys; the user should create a project API key pair there. If they do not have a Langfuse account yet, share that they can create one for free at `https://langfuse.com/cloud`. Do not ask them to paste keys into chat for security reasons.
 
 ### Detailed CLI Reference
 


### PR DESCRIPTION
Summary: Flesh out the central Langfuse skill credential guidance: when keys are missing, tell the user to set them in shell or .env, explain that keys are found in the Langfuse project under Settings -> API Keys, tell them to create a project API key pair there, and share https://langfuse.com/cloud if they do not have a Langfuse account yet. Keep the instruction to avoid asking users to paste secrets into chat. Bump both plugin manifests from 1.4.3 to 1.4.4. Validation: git diff --check passed; SKILL.md frontmatter parsed with Ruby YAML; both plugin manifests parsed as JSON. Note: bundled quick_validate.py could not run because PyYAML is not installed in the available Python runtimes.