### PR TITLE
Remove stale and volatile Langfuse skill guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/skills/langfuse/references/judge-calibration.md
+++ b/skills/langfuse/references/judge-calibration.md
@@ -192,8 +192,10 @@ Before trusting the judge on production traffic:
 3. **Metric recomputation check**: recompute aggregate stats from row-level
    flags and compare.
 4. **TPR/TNR review**: inspect both directions for class-direction bias.
-5. **Threshold**: target `TPR > 0.90` and `TNR > 0.90` before high-stakes
-   automation.
+5. **Acceptance criteria**: before the held-out test, agree on thresholds for
+   the relevant metrics based on the costs of false positives and false
+   negatives and whether the judge informs monitoring or automation. Do not
+   infer "ship" from a universal cutoff.
 
 ## 7) Report format
 
@@ -223,10 +225,10 @@ scores to the experiment traces and run-level scores to the dataset run.
 Use manual REST score creation only as a fallback when not using the SDK
 experiment runner, or for local smoke tests. See
 [Scores via SDK](https://langfuse.com/docs/evaluation/evaluation-methods/scores-via-sdk)
-and the [Scores API reference](https://langfuse.com/docs/api) (`POST /api/public/scores`)
-for the current payload shape. Do not use the current `langfuse-cli` score-create
-wrapper unless `--help` shows a usable `value` argument; `langfuse-cli@0.0.10`
-exposes `legacy-score-v1s create` but cannot pass the required score `value`.
+and the [Scores API reference](https://langfuse.com/docs/api) for the current
+payload shape. Before using the CLI for score creation, inspect its current
+schema and action help instead of assuming resource names, arguments, or
+capabilities from a known package version.
 
 Score names to emit:
 

--- a/skills/langfuse/references/user-feedback.md
+++ b/skills/langfuse/references/user-feedback.md
@@ -45,37 +45,11 @@ Rules:
 
 ### 3. Implement Score Creation
 
-**For implicit feedback (server-side):** Use `langfuse.create_score()` / `langfuse.score.create()` wherever the event is already handled in application code. Fetch SDK docs for current API: https://langfuse.com/docs/evaluation/evaluation-methods/scores-via-sdk
+Fetch and follow the current [user feedback guide](https://langfuse.com/docs/observability/features/user-feedback) and [score ingestion docs](https://langfuse.com/docs/evaluation/evaluation-methods/scores-via-sdk) before editing code. They contain the current browser and server SDK APIs plus framework-specific patterns for returning trace IDs to the frontend.
 
-**For explicit feedback (frontend):** Use `LangfuseWeb` in the browser. It uses the public key only — no secret key exposed.
+**For implicit feedback (server-side):** Create the score where the behavior is already handled in application code.
 
-```typescript
-import { LangfuseWeb } from "langfuse";
-
-const langfuse = new LangfuseWeb({
-  publicKey: process.env.NEXT_PUBLIC_LANGFUSE_PUBLIC_KEY!,
-  baseUrl: process.env.NEXT_PUBLIC_LANGFUSE_HOST,
-});
-
-langfuse.score({
-  traceId,
-  name: "user-thumbs",
-  value: 1, // 1 = positive, 0 = negative
-  dataType: "BOOLEAN",
-  comment: optionalUserComment,
-});
-```
-
-The trace ID must be available in the frontend for this to work. For Vercel AI SDK, the non-obvious pattern is using `generateMessageId`:
-
-```typescript
-import { getActiveTraceId } from "@langfuse/tracing";
-
-// Inside route handler wrapped with observe()
-return result.toUIMessageStreamResponse({
-  generateMessageId: () => getActiveTraceId() || crypto.randomUUID(),
-});
-```
+**For explicit feedback (frontend):** Make the relevant trace ID available to the frontend and use the current Langfuse browser SDK with a public key only. Never expose a Langfuse secret key in browser code.
 
 ### 4. Verify
 
@@ -87,6 +61,6 @@ Point users to what they can do with feedback data: filter traces by low scores,
 
 | Mistake | Problem | Fix |
 |---------|---------|-----|
-| Secret key in frontend code | Security risk | Use `LangfuseWeb` with public key only |
+| Secret key in frontend code | Security risk | Use the current browser SDK with a public key only |
 | Missing `dataType` on boolean scores | Value `1` inferred as `NUMERIC` | Always pass `dataType: "BOOLEAN"` explicitly |
 | Inconsistent score names across the app | Can't aggregate or filter reliably | Pick one name per feedback type, use it everywhere |


### PR DESCRIPTION
## Summary

- remove stale user-feedback SDK examples and defer implementation details to current Langfuse docs
- retain durable frontend/server feedback workflow and security guidance
- replace the universal judge-calibration cutoff with use-case-specific acceptance criteria
- discover CLI score-creation capabilities from current schema and help instead of a pinned package version
- bump both plugin manifests to 1.5.2

## Validation

- git diff --check origin/main...HEAD
- validated both plugin manifests as JSON
- confirmed manifest versions remain in lockstep
- confirmed SKILL.md is unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and plugin version metadata only; no runtime code or security-sensitive logic changes.
> 
> **Overview**
> **Updates Langfuse skill references** so agents rely on live docs instead of copy-pasted SDK snippets, and **bumps** the Claude and Cursor plugin manifests from **1.5.0** to **1.5.2**.
> 
> In **user-feedback**, the inlined `LangfuseWeb` / Vercel AI SDK examples are removed in favor of pointers to the current user-feedback and score-ingestion guides, while keeping the workflow (implicit vs explicit feedback, public-key-only in the browser, naming rules, and common mistakes).
> 
> In **judge-calibration**, the fixed **TPR/TNR > 0.90** ship gate is replaced with **use-case-specific acceptance criteria** (false positive/negative costs and monitoring vs automation). CLI score-creation advice no longer pins `langfuse-cli@0.0.10`; it tells readers to inspect current schema and `--help` instead of assuming capabilities from a version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55f9442c9bb319b40a2c58a05f78d423719c7010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->