### PR TITLE
docs: clarify that trace queries should use observations endpoint

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/skills/langfuse/references/cli.md
+++ b/skills/langfuse/references/cli.md
@@ -56,5 +56,5 @@ export LANGFUSE_BASE_URL=https://cloud.langfuse.com
 - Prefer `observations` over `legacy-observations-v1s` — `observations` is the modern high-performance endpoint (cursor pagination, selective field groups); `legacy-observations-v1s` is the deprecated v1
 - Prefer `metrics` over `legacy-metrics-v1s` for the same reason
 - Prefer `scores` over `legacy-score-v1s` for list/get operations
-- For broad trace queries, `traces list` can time out on Langfuse Cloud — use `observations list` (with `--trace-id` if you're traversing from a known trace) instead. See the [Observations API docs](https://langfuse.com/docs/api-and-data-platform/features/observations-api) for the v1 → v2 mapping.
+- Users almost always say "traces," but the modern query endpoint is `observations`, not `traces` — the `traces` endpoints are outdated. Always query via `observations` (add `--trace-id` to scope to a known trace), even when the request is phrased in terms of traces. See the [Observations API docs](https://langfuse.com/docs/api-and-data-platform/features/observations-api) for the v1 → v2 mapping.
 - Pagination: legacy v1 endpoints use `--limit` and `--page`; modern endpoints (`observations`, `metrics`, `scores`) use cursor-based pagination — pass `--limit`, then thread `meta.cursor` from the response into the next request's `--cursor`

--- a/skills/langfuse/references/cli.md
+++ b/skills/langfuse/references/cli.md
@@ -56,5 +56,5 @@ export LANGFUSE_BASE_URL=https://cloud.langfuse.com
 - Prefer `observations` over `legacy-observations-v1s` — `observations` is the modern high-performance endpoint (cursor pagination, selective field groups); `legacy-observations-v1s` is the deprecated v1
 - Prefer `metrics` over `legacy-metrics-v1s` for the same reason
 - Prefer `scores` over `legacy-score-v1s` for list/get operations
-- Users almost always say "traces," but the modern query endpoint is `observations`, not `traces` — the `traces` endpoints are outdated. Always query via `observations` (add `--trace-id` to scope to a known trace), even when the request is phrased in terms of traces. See the [Observations API docs](https://langfuse.com/docs/api-and-data-platform/features/observations-api) for the v1 → v2 mapping.
+- Always query via `observations`, not `traces`, even when the user phrases the request in terms of traces — the `traces` endpoints are outdated (add `--trace-id` to scope to a known trace). See the [Observations API docs](https://langfuse.com/docs/api-and-data-platform/features/observations-api) for the v1 → v2 mapping.
 - Pagination: legacy v1 endpoints use `--limit` and `--page`; modern endpoints (`observations`, `metrics`, `scores`) use cursor-based pagination — pass `--limit`, then thread `meta.cursor` from the response into the next request's `--cursor`


### PR DESCRIPTION
Users almost always describe their data as "traces," but the modern query endpoint in the CLI and API is `observations`, not `traces`. The `traces` endpoints are outdated. This updates the CLI reference tip so agents default to `observations` even when a request is phrased in terms of traces.

Bumps both plugin manifests `1.5.2` → `1.5.3` (patch, in lockstep) for the skill-content clarification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and version metadata only; no runtime or API behavior changes.
> 
> **Overview**
> **Documentation update** so agents and users route trace-style questions through the modern `observations` CLI/API instead of deprecated `traces` endpoints.
> 
> The CLI reference **Tips** section now states to **always** use `observations` (optionally with `--trace-id` for a known trace), replacing the narrower note about `traces list` timeouts on Langfuse Cloud. Plugin manifests for Claude and Cursor are bumped **1.5.2 → 1.5.3** in lockstep for this skill-content change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f55ccc441d7333029d9e56eaa98908b0d6aa1c72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->