### PR TITLE
docs: fix skills CLI link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install as a [Cursor plugin](https://cursor.com/docs/plugins):
 
 ### skills CLI
 
-Install via the [skills CLI](https://github.com/anthropics/skills):
+Install via the [skills CLI](https://github.com/vercel-labs/skills):
 
 ```bash
 npx skills add langfuse/skills --skill "langfuse"


### PR DESCRIPTION
README was linked to anthropics/skills instead of the actual skills CLI (vercel-labs/skills)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link correction with no runtime or security impact.
> 
> **Overview**
> Updates the **skills CLI** install link in the README from `anthropics/skills` to **`vercel-labs/skills`**, so installation docs point at the CLI users actually run with `npx skills add`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2352539b81fb2a310cfc7d1ea0428be8b813d9c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->