### PR TITLE
feat(langfuse): add setting-up-evals reference for eval setup guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -34,13 +34,14 @@ Follow these principles for ALL Langfuse work:
 - instrumenting an existing function/application: references/instrumentation.md
 - migrating prompts from a codebase into Langfuse: references/prompt-migration.md
 - creating a prompt or changing any part of an existing prompt, including small edits and debugging/tuning: references/prompt-engineering.md
+- setting up evals when the user needs to identify gaps across signal capture, monitoring, and evaluator metrics ("I have traces, how do I set up evals?"): references/setting-up-evals.md
 - capturing user feedback (thumbs, ratings, implicit signals) as scores on traces: references/user-feedback.md
 - further tips on using the Langfuse CLI: references/cli.md
 - upgrading or migrating Langfuse SDKs and preserving application instrumentation attributes: references/sdk-upgrade.md
 - upgrading legacy trace-level or dataset-item evaluators to observation-level or experiment evaluators: references/trace-evaluator-upgrade.md. Use the [evaluator migration guide](https://langfuse.com/faq/all/llm-as-a-judge-migration) as the primary reference.
 - preparing a Langfuse project for the v4 platform migration: references/v4-project-migration.md
 - judge calibration (LLM-as-a-Judge reliability, simple accuracy checks, advanced split-based validation, confusion matrices, and metric ingestion): references/judge-calibration.md
-- systematic error analysis — reading traces, building failure taxonomy, deciding what to fix: references/error-analysis.md
+- systematic error analysis when requested directly or eval setup still lacks concrete failure modes after agent-led trace inspection: references/error-analysis.md
 - setting up CI/CD experiment gates with `langfuse/experiment-action`: references/ci-cd.md
 - submitting feedback about this skill: references/skill-feedback.md
 

--- a/skills/langfuse/references/error-analysis.md
+++ b/skills/langfuse/references/error-analysis.md
@@ -2,12 +2,10 @@
 name: langfuse-error-analysis
 description: Deep-dive error analysis of an LLM pipeline or AI application using Langfuse traces.
   Use this skill whenever the user wants to understand why their AI system is producing
-  bad outputs, where their pipeline is failing, how to categorise or label failures,
-  what to prioritise fixing, or how to set up evaluators. Also trigger for "review my
+  bad outputs, where their pipeline is failing, or how to categorise and label failures
+  into a taxonomy and decide what to prioritise fixing. Also trigger for "review my
   traces", "my outputs look wrong", "help me debug my LLM app", "I want to analyse
-  errors", "build a failure taxonomy", "what's going wrong with my pipeline", or any
-  request to systematically inspect, annotate, or score Langfuse traces. If the user
-  is trying to understand or improve the quality of an AI system's outputs, use this skill.
+  errors", "build a failure taxonomy", or "what's going wrong with my pipeline".
 metadata:
   required_access:
     - LANGFUSE_PROJECT_INTERFACE
@@ -27,12 +25,13 @@ Read it in full. It defines the authoritative 5-step process (sample selection â
 
 **2. Guide the user through this step by step**
 
-You as a coding agent and the user go through this together to perform a full error analysis with their data in langfuse. Do as much of the work as you can directly for the user (look up traces, create annotation queues, ...). Provide them with direct links to UI wherever their action is required. Be proactive and narrate what is going on for the user. 
+You as a coding agent and the user go through this together to perform a full error analysis with their data in Langfuse. Set up the scores, representative sample, and annotation queue for the user, and provide direct UI links wherever their action is required. Be proactive and explain what is happening in plain language without reciting internal step numbers or jargon.
 
 ## Rules CRITICAL
-Perform interactions with the user's Langfuse instance yourself rather than telling the user to do them â€” don't say "now do this in Langfuse" when you can do it directly
-But don't barrel through on assumptions: where a step needs the user's judgment or input (e.g. what to fix, how to label, which evaluator), pause and ask before acting
-Use charts where possible to display data
+- Perform interactions with the user's Langfuse instance yourself rather than telling the user to do them.
+- The user performs the open-coding review and supplies human labels; do not do this on their behalf.
+- Where a step needs the user's judgment or input, pause and ask before acting.
+- Use charts where possible to display data.
 
 ---
 

--- a/skills/langfuse/references/error-analysis.md
+++ b/skills/langfuse/references/error-analysis.md
@@ -73,7 +73,7 @@ When a category warrants a prompt fix, always offer the user two options:
 
 ### Setup evaluators
 
-When a category warrants an evaluator setup, propose the type of evaluator and offer to set it up for the user
+When a category warrants an evaluator, build it following `references/setting-up-evals.md`.
 
 
 ### Common gotchas

--- a/skills/langfuse/references/setting-up-evals.md
+++ b/skills/langfuse/references/setting-up-evals.md
@@ -31,7 +31,7 @@ Treat trace errors and logged failures as existing coverage. Unless the user wan
 
 Do not propose evaluating a known failure with an owner and a planned one-time fix unless the user wants to track whether it recurs.
 
-If formal error analysis is the right next step, explain why and ask whether the user wants to do it. If they agree, set up the scores, representative sample, and annotation queue, then guide the user through the review. If you start error analysis, do not start metric selection until the analysis is complete.
+If formal error analysis is the right next step, explain why and ask whether the user wants to do it. If they agree, run it following `references/error-analysis.md`, and do not start metric selection until the analysis is complete.
 
 ## Define the metric set
 

--- a/skills/langfuse/references/setting-up-evals.md
+++ b/skills/langfuse/references/setting-up-evals.md
@@ -1,0 +1,63 @@
+---
+name: langfuse-setting-up-evals
+description: Set up evaluation by finding gaps across signal capture, monitoring, and evaluator metrics, then addressing the right one first.
+metadata:
+  required_access:
+    - LANGFUSE_PROJECT_INTERFACE
+---
+
+# Setting up evals
+
+- **Act as executor and teacher.** Do the work and, above all, explain why the approach fits the user's goal and data.
+- **Teach decision-making, not configuration.** Explain the reasoning, tradeoffs, and limitations—not sampling rates, targets, score types, or other setup details. The response must leave the user able to repeat or change the approach and make future decisions without you.
+
+Always read [Choosing what to evaluate](https://langfuse.com/academy/evaluate/choosing-what-to-evaluate) and [Evaluation](https://langfuse.com/academy/evaluate). Use their guidance to interpret their project, but do not return it as a generic setup plan.
+
+If the user has a precise metric, skip to **Build the evaluator**. Otherwise, do not assume that choosing evaluator metrics is the next step.
+
+## Find the measurement gap
+
+Before advising:
+
+- Inspect enough representative traces to present concrete findings of your own before asking about metrics.
+- Inventory existing datasets, evaluators, traces, etc. as context; do not assume they should be reused or represent a current priority. Treat their importance as unconfirmed until the user agrees.
+- Identify what is already surfaced through trace errors, logged data, existing scores, or other monitoring; what is available but not monitored; what important user or product signals are not captured; and what genuinely requires an evaluator.
+- Do not ask the user for information you can inspect.
+- If project access is unavailable, say so instead of substituting a generic plan.
+
+Do not add an evaluator that duplicates an existing error or logged signal. For example, do not evaluate valid JSON when invalid JSON already produces a trace error.
+
+Treat trace errors and logged failures as existing coverage. Unless the user wants operational monitoring, do not let them displace the search for subtler qualitative signals that are not yet captured. Do not propose alerts, paging, or release gates before asking how the measurement should be used.
+
+Do not propose evaluating a known failure with an owner and a planned one-time fix unless the user wants to track whether it recurs.
+
+If formal error analysis is the right next step, explain why and ask whether the user wants to do it. If they agree, set up the scores, representative sample, and annotation queue, then guide the user through the review. If you start error analysis, do not start metric selection until the analysis is complete.
+
+## Define the metric set
+
+Existing project materials inform the questions you'll ask; it does not determine what the user values.
+
+When forming tentative recommendations:
+
+- Start with direct evidence of user or product outcomes, recurring failures visible in traces or user reactions, and important signals the application is not yet capturing.
+- Prefer quick wins: signals that are application-specific, actionable, reasonably reliable to start measuring. A good example signal is user (dis)satisfaction.
+- Recommend metrics only for problems evidenced in current data. A behavior being common or theoretically risky is not a reason to run an evaluator.
+- For live evaluation, recommend only metrics that can be scored from the available live data without ground truth; never suggest a metric that requires knowing the correct answer, expected outcome, or ideal resolution.
+- Do not propose generic starting metrics such as `helpfulness`, `quality`, `relevance`, `hallucination`, `groundedness`, `task completion`, `task success`, or `reliability`.
+- Before presenting any metric, verify that it can actually be measured using the available data and Langfuse's supported evaluator inputs. If not, identify what must be captured instead.
+- Explain why each recommendation deserves attention before the alternatives, then ask the user whether that priority matches their goals.
+
+When specific failures or hard requirements are known and metric selection is the next task, ask focused, dependent questions about which ones matter and what decisions their measurement should support. Give a recommendation grounded in the project, leave the decision to the user, and wait for their answer.
+
+Do not treat any metric as selected, choose evaluator types, ask implementation questions, or implement anything until the user has answered and explicitly confirmed the metric set.
+
+## Build the evaluator
+
+For evaluator functionality, use the unstable API endpoints.
+
+Follow [Writing good evaluators](https://langfuse.com/academy/evaluate/writing-evaluators) to choose the evaluator type; do not always default to an LLM-as-a-judge.
+
+- Explain why the chosen evaluation method measures the intended behavior, what evidence it relies on, what it cannot tell the user, and when another method would be better.
+- When methods have significant trade-offs and none is clearly superior, explain the options and let the user decide before implementation.
+- Only if an LLM-as-a-judge is the best fit, calibrate it on real examples before treating it as ready(`references/judge-calibration.md`). You can do this by running an experiment on a dataset where the prompt being tested is the LLM-as-a-judge prompt.
+- Share a link to the evaluator.


### PR DESCRIPTION
## What

Adds `references/setting-up-evals.md`, a new use-case reference for the Langfuse skill that guides an agent when a user wants to set up evaluation for an LLM app.

The reference encodes behavior the docs alone don't produce:
- **Teacher stance** — do the work *and* explain the *why*, so the user can repeat or change the setup without the agent (holds even when a model's system instructions push toward terse, execution-only replies).
- **Find the measurement gap first** — inspect real traces and existing datasets/evaluators/scores/feedback before advising; prefer capturing/monitoring an unmonitored signal over adding a redundant evaluator; don't assume choosing evaluator metrics is the next step.
- **Define the metric set with the user** — project evidence informs the interview but doesn't decide what the user values; recommend from real evidence, avoid generic metrics (helpfulness/quality/groundedness/…), and don't treat a metric as selected until the user confirms.
- **Build the right evaluator** — don't default to LLM-as-a-judge; measure a signal from its true source (e.g. user dissatisfaction from the user's turns, not the agent's answer); calibrate any judge before trusting it.

## Supporting changes
- `SKILL.md`: adds one routing entry for the new reference and scopes the error-analysis entry to trigger on direct requests or when eval setup still lacks concrete failure modes.
- `error-analysis.md`: tightens the description to failure-taxonomy scope (drops "set up evaluators"), and clarifies that the user performs the open-coding/human labeling, not the agent.
- Version bump `1.6.0 → 1.7.0` in `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` (new capability; kept in lockstep).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-routing only for the Langfuse skills plugin; no runtime application or security-sensitive code changes.
> 
> **Overview**
> **Adds a dedicated eval-setup workflow** for the Langfuse skill via new `references/setting-up-evals.md`, and bumps the Claude/Cursor plugin versions to **1.7.0**.
> 
> The new reference steers agents to **find measurement gaps first** (inspect traces, inventory existing signals/evaluators, avoid redundant evaluators and generic metrics), **define metrics with explicit user confirmation**, then **build evaluators** (non-default types, unstable APIs, judge calibration when needed) while acting as executor and teacher.
> 
> **`SKILL.md`** routes “I have traces, how do I set up evals?” to the new doc and narrows **error analysis** to direct requests or when eval setup still lacks concrete failure modes after trace inspection.
> 
> **`error-analysis.md`** is scoped to failure taxonomy/debugging (no longer a trigger for generic evaluator setup), clarifies that **users** do open-coding/labels, and points evaluator work to `setting-up-evals.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b95caab5d8cc6bba6eaae7232b5344fb804499f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->