### PR TITLE
feat(evals): guide filter verification and clean score naming

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/skills/langfuse/references/setting-up-evals.md
+++ b/skills/langfuse/references/setting-up-evals.md
@@ -57,6 +57,8 @@ For evaluator functionality, use the unstable API endpoints.
 
 Follow [Writing good evaluators](https://langfuse.com/academy/evaluate/writing-evaluators) to choose the evaluator type; do not always default to an LLM-as-a-judge.
 
+- Before creating the evaluator, verify its target filter by fetching the observations it actually matches. Confirm the set is exactly what you intend—no duplicates that would be scored (and billed) twice.
+- Prioritize a clean score name: it is the metric that lands on every observation, so name it after what is measured (`refusal`), not after the evaluator (`refusal judge`). Keep any evaluator-mechanism wording out of the score name.
 - Explain why the chosen evaluation method measures the intended behavior, what evidence it relies on, what it cannot tell the user, and when another method would be better.
 - When methods have significant trade-offs and none is clearly superior, explain the options and let the user decide before implementation.
 - Only if an LLM-as-a-judge is the best fit, calibrate it on real examples before treating it as ready(`references/judge-calibration.md`). You can do this by running an experiment on a dataset where the prompt being tested is the LLM-as-a-judge prompt.


### PR DESCRIPTION
## What

Adds two authoring remarks to the **Build the evaluator** section of `setting-up-evals.md`:

- **Verify the target filter before creating the evaluator.** Agents sometimes create an evaluator without checking which observations the filter actually matches, leading to duplicate observations (e.g. the same logical step logged as both an observation and a child observation) being scored — and billed — twice. The remark tells the agent to fetch the matched observations first and confirm the set is exactly what's intended.
- **Prioritize a clean score name.** The score name lands on every observation, so it should describe what is measured (`refusal`) rather than the evaluator mechanism (`refusal judge`).

Bumps both plugin manifests to `1.7.1` (patch) since published skill content changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and plugin version metadata only; no runtime or API behavior changes.
> 
> **Overview**
> Updates the **Build the evaluator** guidance in `setting-up-evals.md` so agents **verify the target filter** (fetch matched observations before creating an evaluator) to avoid duplicate scoring and billing, and **name scores after the metric** (e.g. `refusal`) rather than the evaluator mechanism.
> 
> Bumps the Claude and Cursor plugin manifests from **1.7.0** to **1.7.1** to reflect the published skill content change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 131781b2680777a9eeb5b0ee622fbce335148175. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->