### PR TITLE
feat(instrumentation): add multi-modal media guidance to baseline table

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/skills/langfuse/references/instrumentation.md
+++ b/skills/langfuse/references/instrumentation.md
@@ -52,7 +52,7 @@ Docs: https://langfuse.com/docs/tracing
 | Multiple distinct endpoints/features                 | `feature` tag       | Per-feature analytics — [docs](https://langfuse.com/docs/tracing-features/tags) |
 | Customer/tenant identifiers                          | `customer_tier` tag | Cost/quality breakdown by segment — [docs](https://langfuse.com/docs/tracing-features/tags) |
 | Feedback collection, ratings                         | Feedback score      | Quality filtering and trends — [docs](https://langfuse.com/docs/scores/overview) |
-| Image/audio/file input or output (e.g. image generation, vision) | Media in observation input/output | Renders media in the UI; base64 uploads automatically, `LangfuseMedia` for URLs. Follow the [multi-modality docs](https://langfuse.com/docs/observability/features/multi-modality) to implement |
+| Image/audio/file input or output (e.g. image generation, vision) | Media in observation input/output | Renders media in the UI; base64 data URIs and external URLs are handled automatically, wrap raw bytes/files in `LangfuseMedia`. Follow the [multi-modality docs](https://langfuse.com/docs/observability/features/multi-modality) to implement |
 
 ### 3. Run and Self-Audit the Traces (required)
 

--- a/skills/langfuse/references/instrumentation.md
+++ b/skills/langfuse/references/instrumentation.md
@@ -52,6 +52,7 @@ Docs: https://langfuse.com/docs/tracing
 | Multiple distinct endpoints/features                 | `feature` tag       | Per-feature analytics — [docs](https://langfuse.com/docs/tracing-features/tags) |
 | Customer/tenant identifiers                          | `customer_tier` tag | Cost/quality breakdown by segment — [docs](https://langfuse.com/docs/tracing-features/tags) |
 | Feedback collection, ratings                         | Feedback score      | Quality filtering and trends — [docs](https://langfuse.com/docs/scores/overview) |
+| Image/audio/file input or output (e.g. image generation, vision) | Media in observation input/output | Renders media in the UI; base64 uploads automatically, `LangfuseMedia` for URLs. Follow the [multi-modality docs](https://langfuse.com/docs/observability/features/multi-modality) to implement |
 
 ### 3. Run and Self-Audit the Traces (required)
 


### PR DESCRIPTION
## What

Adds a single conditional row to the "beyond the baseline" table in `instrumentation.md` covering multi-modal apps (image generation, vision, audio, files).

## Why

An agent instrumenting an image-generation app previously had no signal in the instrumentation reference that Langfuse supports media, so it burned multiple turns discovering the right docs page by trial search. The row gives the trigger, the one non-obvious insight (base64 data URIs upload automatically; `LangfuseMedia` for external URLs), and a direct link to the multi-modality docs to implement from — without duplicating the docs' format/MIME tables.

It lives as one table row rather than its own section, since multi-modal is an edge case that doesn't warrant added prominence.

Patch version bump (`1.7.1` → `1.7.2`) in both plugin manifests, in lockstep.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and manifest version-only changes with no runtime or security impact.
> 
> **Overview**
> Adds a **beyond-the-baseline** row in `instrumentation.md` so agents instrumenting vision, image generation, audio, or file I/O know to put **media on observation input/output**, that base64 data URIs and external URLs are handled automatically, and to use **`LangfuseMedia`** for raw bytes/files, with a link to the multi-modality docs.
> 
> Bumps the Langfuse skills plugin version from **1.7.1 → 1.7.2** in `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c69ce0e7c33c65c861d9cd23a99ef960be9016ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->