### PR TITLE
Feat/migrate to langfuse skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": {
     "name": "Langfuse",
     "email": "support@langfuse.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse",
   "displayName": "Langfuse",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Skills for working with Langfuse — the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
   "author": {
     "name": "Langfuse",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,12 @@ When changing the path to any Langfuse skill in this repo, you must also update 
 
 ## Plugin Version Bumps
 
-The repo ships as a plugin to two marketplaces, each with its own manifest:
+The repo ships as a plugin to three marketplaces, each with its own manifest:
 - `.claude-plugin/plugin.json` (Claude Code)
+- `.codex-plugin/plugin.json` (Codex)
 - `.cursor-plugin/plugin.json` (Cursor)
 
-Both manifests have a `version` field and **must stay in lockstep** — always bump them together to the same value, in the same PR as the change.
+All manifests have a `version` field and **must stay in lockstep** — always bump them together to the same value, in the same PR as the change.
 
 When to bump (follow semver):
 - **Patch** (`1.0.0` → `1.0.1`): bug fixes in a skill, clarifications to skill instructions, small content corrections.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 | Skill                                                           | Description                                                                                        |
 | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | [langfuse](./skills/langfuse)                                   | Main skill to work with Langfuse. Query and manage traces, prompts, datasets, and scores via the Langfuse API; look up documentation; do things with best practices in mind. |
+| [migrate-to-langfuse](./skills/migrate-to-langfuse)             | Migrate from another LLM observability/evals platform (LangSmith, Arize, Braintrust, etc.) to Langfuse. Interviews you about scope, then handles the live tracing cutover and transfer of historical traces, datasets, prompts, and evaluators. |
 
 ## Installation
 

--- a/skills/migrate-to-langfuse/SKILL.md
+++ b/skills/migrate-to-langfuse/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: migrate-to-langfuse
+description: >-
+  Migrate to Langfuse from another LLM observability/evals platform (LangSmith, Arize AX, Phoenix, Braintrust, Helicone, Promptfoo, ...). A one-off vendor switch: live tracing cutover plus transfer of historical traces, datasets, prompts, and evaluators. Not for anything Langfuse-to-Langfuse — SDK or version upgrades, project/region moves, self-hosted to Cloud — and not for moving in-code prompts into Langfuse; the main langfuse skill covers those.
+allowed-tools:
+  - WebFetch(domain:langfuse.com)
+  - Bash(curl *langfuse.com/*)
+---
+
+# Migrate to Langfuse
+
+You are running a one-off vendor switch to Langfuse. Interview first, plan second, execute only after confirmation. Never implement from memory — fetch the current Langfuse docs listed below at execution time.
+
+## 1. Interview (always, before any code)
+
+Ask only what you cannot detect. Inspect the repo first: dependencies and imports usually reveal the source platform (`langsmith`, `arize`, `phoenix`, `braintrust`, `openinference`, old `langfuse` pins).
+
+1. **Source** — which platform and version? Cloud or self-hosted? What access exists: API keys, a database connection, or only the application repo?
+2. **Destination** — Langfuse Cloud (which region) or self-hosted? Verify credentials by presence only (e.g. `[ -n "$LANGFUSE_SECRET_KEY" ]`); never ask for secrets in chat, and never access `.env` contents or key values by any means — no shell commands that echo them, no reading `.env` with file tools, no grepping for values. Detect which variable names are set, nothing more.
+3. **Scope** — which of: live tracing cutover, historical traces, datasets, prompts, evaluators/LLM judges, experiment code. For history: everything or from a cutoff date?
+4. **Mode** — plan only (a written runbook) or execute?
+
+If the request contradicts the repository (it names a platform that is not present, or asks to upgrade an SDK that is not installed), stop and reconcile with the user first — never reinterpret the request as a different migration and start executing it.
+
+Present the resulting plan (scope table plus order of operations) and get the user's confirmation before changing any file. However imperative the request sounds, it does not authorize removing or replacing the existing vendor's instrumentation before the plan is confirmed.
+
+## 2. Defaults to apply
+
+- **Live cutover first.** Historical data migration is optional and billed as new ingestion in Langfuse — say so before migrating history. If the source already emits OTel/OpenInference spans, repoint the exporter instead of re-instrumenting.
+- **Datasets and prompts copy. Evaluators and judges are recreated.** Experiment code is rewritten and re-run against the migrated dataset; never import old experiment scores.
+- **Test on a sample before the full run.** Migrate ~10 traces first, link the destination traces, and wait for the user to confirm they look correct before migrating everything.
+- **Show progress** (pages/counts) during long runs and make re-runs idempotent (deterministic destination IDs).
+- **Parallel-run window.** Keep the old exporter until the user confirms the destination data, then remove it in a separate, explicit step. This binds the implementation, not just the plan: after your edits, the old vendor's exporter/instrumentation must still be present and active. Before showing a diff, re-check that no vendor import or register call was deleted or replaced. Implement parallel export as **one instrumentation with two exporters** (both span processors on the same tracer provider) — never instrument the application twice. Duplicated generations and double-counted costs in the destination are the symptom of a second capture path.
+
+## 3. Route by scenario
+
+Fetch and follow; do not reproduce their content:
+
+| Scenario | Source of truth |
+| --- | --- |
+| Vendor with a published guide (Arize AX, Phoenix, Braintrust, Helicone, Promptfoo, ...) | `https://langfuse.com/resources/engineering/migrate-from-<vendor>.md` — check `https://langfuse.com/llms.txt` for the current list |
+| Vendor without a published guide, or historical data from any vendor | references/reingest-history.md, plus the vendor's own export API docs |
+
+Historical-trace reingestion is never improvised: read references/reingest-history.md in full before writing or running any reingestion code, even when a vendor guide exists. The vendor guide covers extraction; the reference governs reingestion — deterministic IDs, raw OTLP payloads, original timestamps, the cutover-time bound, and the warning that imported history is billed as new ingestion.
+
+If the source turns out to be another Langfuse deployment (an older version, a different project, region, or host), stop — that is not a vendor switch. Point the user to the main langfuse skill (its SDK-upgrade and v4-migration references) and the [project-to-project migration cookbook](https://langfuse.com/guides/cookbook/example_data_migration).
+
+For the live instrumentation cutover, use the integration guide matching the user's framework or SDK from https://langfuse.com/llms.txt. For deep Langfuse-side work (prompt creation, dataset APIs, experiment code), defer to the main langfuse skill if installed.
+
+## 4. Verify and close
+
+- Sample check confirmed by the user in the destination UI before the full run.
+- Before asking the user to confirm a live-cutover sample, audit it yourself via the Langfuse API or CLI: one trace per request; the root span named after the agent/app (and the trace named after the root); every span type present (generations **and** tool/chain spans); each LLM call captured exactly once; token usage and cost populated. Only then send the user the trace links.
+- Counts match per migrated data type (source vs destination); report a summary table including failures.
+- Live traffic arrives in the destination; the old exporter is removed only after the parallel-run window the user chose.

--- a/skills/migrate-to-langfuse/references/reingest-history.md
+++ b/skills/migrate-to-langfuse/references/reingest-history.md
@@ -1,0 +1,37 @@
+---
+name: migrate-to-langfuse-reingest-history
+description: Write and run a script that extracts traces, scores, datasets, and prompts from a source system and reingests them into Langfuse with original timestamps.
+metadata:
+  required_access:
+    - CODEBASE
+    - LANGFUSE_PROJECT_SCRIPT
+---
+
+# Reingest historical data into Langfuse
+
+Build a one-off script: extract from the source, transform to the Langfuse observation model, reingest. Extract using the source vendor's **documented** export mechanism (SDK export client or documented API, as named in the matching migration guide on langfuse.com) — never guess REST endpoints or hostnames. If an export call fails with 404/405, stop and re-read the vendor guide instead of trying endpoint variants. Adapt the working implementation in the [project-to-project migration cookbook](https://langfuse.com/guides/cookbook/example_data_migration) — its OTLP reingestion, retry, and ID-mapping code applies to any source.
+
+## Transform target
+
+Fetch [migrate custom ingestion to v4](https://langfuse.com/integrations/native/opentelemetry/migration-to-v4) for the current span format and attributes. Non-negotiables:
+
+- POST OTLP JSON to `/api/public/otel/v1/traces`, building the payload as plain JSON — the only path that preserves original `start_time`/`end_time`. Do not create the spans through an OTel or Langfuse SDK tracer: tracers assign new timestamps and random trace/span IDs, and offer no way to set either.
+- Destination IDs must be OTel-shaped: 32-hex-char trace IDs, 16-hex-char span IDs. Derive them deterministically from source IDs (e.g. a sha256 prefix) so re-runs upsert instead of duplicating. Verify after the sample run that the destination trace IDs match the computed ones — if they do not, the spans went through a tracer.
+- Map source spans to Langfuse observation types (generation, tool, agent, span) and set `gen_ai.usage.*` and model attributes so token usage and cost tracking work. Put user, session, tags, and metadata in the documented `langfuse.*` trace attributes; overall input/output goes on the root observation.
+
+## Migration order
+
+Dependencies dictate order: score configs → custom model definitions → prompts (all versions, in version order, then labels) → observations (traces) → scores → datasets (items, then run items linked to migrated traces). Skip whatever the user excluded in the interview.
+
+Not migratable via API (tell the user; do not attempt): LLM-as-a-Judge evaluator configurations, custom dashboards, users/RBAC, project settings. Recreate evaluators in the destination instead, and re-run experiments rather than importing their scores.
+
+## Execution protocol
+
+1. **Cutoff filter** from the interview goes into the source extraction query, not post-hoc filtering. If the live cutover already happened, also bound the window at the cutover time — traces after it are already arriving in the destination, and reingesting them duplicates data.
+2. **Sample run first**: ~10 traces spanning the date range. Print direct links to the destination traces and stop until the user confirms they look correct — hierarchy, timestamps, token usage and cost, scores attached.
+3. **Full run**: paginate the source, batch the ingestion, print progress (`page X — N traces migrated, M failed`), and collect failures with their source IDs into a retry file instead of aborting. Skip the trace IDs already sent in the sample run — re-sending them is billed again and is wasteful even though deterministic IDs make it safe.
+4. **Reconcile**: compare source vs destination counts per data type and report the table. Count **distinct observation IDs**, not rows: Langfuse deduplicates same-ID re-ingests asynchronously, so an API listing taken shortly after a re-send can show the same observation twice until the background merge collapses it. Same-ID doubles are transient, not a migration bug. Remind the user that reingested history is billed as new ingestion.
+
+Historical cost may differ from what the source displayed: the destination recomputes cost from current model prices unless the source's actual cost is carried in the documented cost attributes.
+
+Verify credentials by presence only (`[ -n "$LANGFUSE_SECRET_KEY" ]`); never print secret values.


### PR DESCRIPTION
## Summary

- Adds the `migrate-to-langfuse` skill for one-off migrations from other LLM observability/evals platforms to Langfuse: interview → confirmed plan → execution, parallel dual export by default, vendor guide routing, and a `references/reingest-history.md` reference for historical reingestion (OTLP, deterministic IDs, preserved timestamps).
- README lists the new skill; plugin manifests bumped (minor).

## Testing

- Local end-to-end runs (headless Cursor CLI) against seeded fixture apps for Arize AX, Phoenix (self-hosted), LangSmith, Braintrust (EU endpoint), Promptfoo (evals-only), and Helicone (unreachable source API), each with an independent API audit of the migrated data. Models: Grok 4.6 high fast and GPT-5 mini.
- Harness run per CONTRIBUTING on dataset [`skill-testing/migrate-to-langfuse`](https://cloud.langfuse.com/project/cmq89cdm501bvad0d3ffeadia/datasets/cmu62x8qq0351ad0csdq346da/experiments) (4 items), Claude Code + Codex (`gpt-5.6-sol`), skill (`migrate-to-langfuse-791326a-*`) vs. baseline (`migrate-to-langfuse-baseline-*`): routing 8/8 correct (skill read on exactly the positive items, never on the negatives); without the skill both agents did an unasked hard cutover, with it both interviewed first and kept parallel export.
- Residual: Helicone prompt/history export and the guides' TypeScript snippets are desk-checked only.

## Validation

- Frontmatter and plugin manifests parse; versions bumped in lockstep.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change publishes new agent instructions that can drive live instrumentation edits and bulk historical ingestion into Langfuse; mistakes could duplicate traces or mishandle secrets, though the skill explicitly constrains those behaviors.
> 
> **Overview**
> Adds a new **`migrate-to-langfuse`** agent skill for one-off moves from other LLM observability/evals vendors to Langfuse. The skill enforces **interview → confirmed plan → execution**, routes live cutovers to Langfuse migration guides, and points historical work at **`references/reingest-history.md`** (OTLP JSON ingestion, deterministic IDs, preserved timestamps, sample-then-full runs, cutover bounds).
> 
> **README** lists the skill. **Plugin manifests** for Claude, Codex, and Cursor are bumped in lockstep to **1.9.0** (minor). **AGENTS.md** now treats **three** marketplaces (including Codex) for version-bump and review rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81f285eb32b9105d1ea3b960bec0e630f616ddff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

