### PR TITLE
Update required access for Langfuse dataset creation

### DIFF
--- a/skills/langfuse/references/create-dataset.md
+++ b/skills/langfuse/references/create-dataset.md
@@ -4,7 +4,6 @@ description: Collaborative Langfuse dataset creation workflow. Use when the user
 metadata:
   required_access:
     - LANGFUSE_PROJECT_INTERFACE
-    - LANGFUSE_PROJECT_SCRIPT
 ---
 
 # Langfuse Dataset Construction


### PR DESCRIPTION
Removed LANGFUSE_PROJECT_SCRIPT from required access for dataset creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/metadata-only change to skill access requirements with no runtime or security logic changes.
> 
> **Overview**
> **Tightens access gating** for the Langfuse dataset construction skill: `metadata.required_access` in `create-dataset.md` now lists only `LANGFUSE_PROJECT_INTERFACE`, removing `LANGFUSE_PROJECT_SCRIPT`.
> 
> Agents or tooling that enforce `required_access` can invoke this dataset workflow without script-level project access; behavior of the skill content itself is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc2b509297a1c54a75cf121cbafbb7c185f456b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->